### PR TITLE
Clean up events

### DIFF
--- a/plane/.sqlx/query-1c13ca4f48aba7ddebb5440620eb0813aff74fa98bd1bdede3bf275374e07ffb.json
+++ b/plane/.sqlx/query-1c13ca4f48aba7ddebb5440620eb0813aff74fa98bd1bdede3bf275374e07ffb.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            delete from event\n            where id in (\n                select id\n                from event\n                where created_at < now() - make_interval(days => $1)\n            )\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1c13ca4f48aba7ddebb5440620eb0813aff74fa98bd1bdede3bf275374e07ffb"
+}

--- a/plane/src/cleanup.rs
+++ b/plane/src/cleanup.rs
@@ -1,4 +1,4 @@
-use crate::database::PlaneDatabase;
+use crate::database::{subscribe::EventSubscriptionManager, PlaneDatabase};
 use anyhow::Result;
 
 const CLEANUP_LOOP_INTERVAL_SECONDS: u64 = 60 * 15;
@@ -8,6 +8,7 @@ pub async fn run_cleanup(db: &PlaneDatabase, min_age_days: Option<i32>) -> Resul
 
     if let Some(min_age_days) = min_age_days {
         db.backend().cleanup(min_age_days).await?;
+        EventSubscriptionManager::clean_up_events(&db.pool, min_age_days).await?;
     }
 
     db.clean_up_tokens().await?;

--- a/plane/src/database/mod.rs
+++ b/plane/src/database/mod.rs
@@ -44,7 +44,7 @@ pub async fn connect(db: &str) -> sqlx::Result<PlaneDatabase> {
 
 #[derive(Clone)]
 pub struct PlaneDatabase {
-    pool: PgPool,
+    pub pool: PgPool,
     subscription_manager: Arc<OnceLock<EventSubscriptionManager>>,
 }
 

--- a/plane/src/database/subscribe.rs
+++ b/plane/src/database/subscribe.rs
@@ -263,6 +263,24 @@ impl EventSubscriptionManager {
         }
     }
 
+    pub async fn clean_up_events(db: &PgPool, min_age_days: i32) -> Result<(), sqlx::Error> {
+        sqlx::query!(
+            r#"
+            delete from event
+            where id in (
+                select id
+                from event
+                where created_at < now() - make_interval(days => $1)
+            )
+            "#,
+            min_age_days
+        )
+        .execute(db)
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn get_events_since(
         db: &PgPool,
         since: i32,


### PR DESCRIPTION
This keeps the event table from growing unbounded if `min_age_days` is set on the controller.