### PR TITLE
allow requests to proxy to not have a trailing slash

### DIFF
--- a/plane/src/proxy/rewriter.rs
+++ b/plane/src/proxy/rewriter.rs
@@ -184,7 +184,14 @@ fn extract_bearer_token(parts: &mut uri::Parts) -> Option<BearerToken> {
         panic!("No path and query");
     };
 
-    let (token, path) = path_and_query.path().strip_prefix('/')?.split_once('/')?;
+    let full_path = path_and_query.path().strip_prefix('/')?;
+
+    // Split the incoming path into the token and the path to proxy to. If there is no slash, the token is
+    // the full incoming path, and the path to proxy to is just `/`.
+    let (token, path) = match full_path.split_once('/') {
+        Some((token, path)) => (token, path),
+        None => (full_path, "/"),
+    };
 
     let token = BearerToken::from(token.to_string());
 


### PR DESCRIPTION
Requests to `$CLUSTER/$CONNECTION_TOKEN` fail because they don't have a trailing slash. This PR fixes that by proxying to `/` anyway. (When using a static token, we don't strip the token from the path before proxying. In those cases, this proxies to `/$CONNECTION_TOKEN` (no trailing slash).

This is important because some servers (e.g. Nextjs) will redirect to remove a trailing slash. When this happens, the connection through proxy fails, returning a `400 Bad Request`.