### PR TITLE
Kill all non-Terminated backends on drone start

### DIFF
--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -29,6 +29,7 @@ impl<R: Runtime> Executor<R> {
         let backends: Arc<DashMap<BackendName, Arc<BackendManager<R>>>> = Arc::default();
         let state_store = Arc::new(Mutex::new(state_store));
 
+        #[allow(clippy::unwrap_used)]
         Self::terminate_preexisting_backends(runtime.clone(), state_store.clone())
             .await
             .context("Failed to terminate all preexisting backends! Locks may be violated, Drone aborting startup.")

--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -225,7 +225,7 @@ impl Drone {
         let state_store = StateStore::new(sqlite_connection)?;
 
         let runtime = Arc::new(runtime);
-        let executor = Executor::new(runtime, state_store, config.ip);
+        let executor = Executor::new(runtime, state_store, config.ip).await;
 
         let id = config.name.clone();
         let drone_loop = tokio::spawn(drone_loop(id.clone(), connector, executor));

--- a/plane/src/drone/state_store.rs
+++ b/plane/src/drone/state_store.rs
@@ -203,7 +203,7 @@ impl StateStore {
     }
 
     /// Retrieves a list of all backends that are not in a Terminated state.
-    pub fn active_backends(&self) -> Result<Vec<BackendName>> {
+    pub fn active_backends(&self) -> Result<Vec<(BackendName, BackendState)>> {
         let mut stmt = self.db_conn.prepare(
             r#"
                 select "id", "state"
@@ -220,7 +220,7 @@ impl StateStore {
             let state: BackendState = serde_json::from_str(&state_json)?;
 
             if !matches!(state, BackendState::Terminated { .. }) {
-                active_backends.push(BackendName::try_from(id)?);
+                active_backends.push((BackendName::try_from(id)?, state));
             }
         }
 

--- a/plane/src/drone/state_store.rs
+++ b/plane/src/drone/state_store.rs
@@ -201,6 +201,31 @@ impl StateStore {
 
         Ok(())
     }
+
+    /// Retrieves a list of all backends that are not in a Terminated state.
+    pub fn active_backends(&self) -> Result<Vec<BackendName>> {
+        let mut stmt = self.db_conn.prepare(
+            r#"
+                select "id", "state"
+                from "backend"
+            "#,
+        )?;
+
+        let mut rows = stmt.query([])?;
+        let mut active_backends = Vec::new();
+
+        while let Some(row) = rows.next()? {
+            let id: String = row.get(0)?;
+            let state_json: String = row.get(1)?;
+            let state: BackendState = serde_json::from_str(&state_json)?;
+
+            if !matches!(state, BackendState::Terminated { .. }) {
+                active_backends.push(BackendName::try_from(id)?);
+            }
+        }
+
+        Ok(active_backends)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes the following bug:
* drone process restarts
* drone executor's `apply_action` receives a `BackendAction::Terminate` for a backend that's been running since before the restart
* the `self.backends` map does not contain the backend's manager anymore because the process was restarted
* the drone assumes the backend has been terminated and the backend continues running

Tested locally: running `docker ps` shows that all previously created backends are terminated upon drone agent restart.

Creating a unit test for this might involve a side quest because terminate currently hangs when the backend can't be found. This is a pre-existing issue outside of the scope of this bug, and I think the code here is sufficiently straightforward to merge without a dedicated test.

# Demo
In separate terminals:
```shell
$ ./dev/postgres.sh && ./dev/controller.sh
$ ./dev/drone.sh
$ ./dev/proxy.sh
```

Spawn a bunch:
```shell
$ ./dev/cli.sh connect --cluster 'localhost:9090' --image 'ghcr.io/jamsocket/demo-image-drop-four'
$ ./dev/cli.sh connect --cluster 'localhost:9090' --image 'ghcr.io/jamsocket/demo-image-drop-four'
```

Check what's running in docker:
```shell
$ docker ps
```

Stop the drone process, then restart it, observe that backends get killed:
```
$ ./dev/drone.sh 
...
INFO plane::drone::executor: Terminating preexisting backends backends=[(BackendName("21p3dk3zvlm4jl"), Ready { address: Some(BackendAddr(127.0.0.1:53635)) })...
```

Verify all containers have been killed in docker:
```shell
$ docker ps
```

This is idempotent: stopping and restarting the drone multiple times works without issue.