### PR TITLE
Add docker network support to spawn config

### DIFF
--- a/plane/plane-tests/tests/backend_lifecycle.rs
+++ b/plane/plane-tests/tests/backend_lifecycle.rs
@@ -37,6 +37,7 @@ async fn backend_lifecycle(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: None,

--- a/plane/plane-tests/tests/backend_status_in_response.rs
+++ b/plane/plane-tests/tests/backend_status_in_response.rs
@@ -32,6 +32,7 @@ async fn backend_status_in_response(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: Some(5),

--- a/plane/plane-tests/tests/drone_pools.rs
+++ b/plane/plane-tests/tests/drone_pools.rs
@@ -34,6 +34,7 @@ async fn drone_pools(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: Some(5),

--- a/plane/plane-tests/tests/reuse_key.rs
+++ b/plane/plane-tests/tests/reuse_key.rs
@@ -32,6 +32,7 @@ async fn reuse_key(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: Some(5),

--- a/plane/plane-tests/tests/subdomains.rs
+++ b/plane/plane-tests/tests/subdomains.rs
@@ -31,6 +31,7 @@ async fn subdomains(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: None,
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: Some(5),

--- a/plane/plane-tests/tests/volume_mounts.rs
+++ b/plane/plane-tests/tests/volume_mounts.rs
@@ -43,6 +43,7 @@ async fn volume_mounts(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: Some(Mount::Path(PathBuf::from(mount))),
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: Some(5),
@@ -73,6 +74,7 @@ async fn volume_mounts(env: TestEnvironment) {
                 resource_limits: ResourceLimits::default(),
                 credentials: None,
                 mount: Some(Mount::Bool(true)),
+                network_name: None,
             })
             .unwrap(),
             lifetime_limit_seconds: Some(5),

--- a/plane/src/drone/runtime/docker/commands.rs
+++ b/plane/src/drone/runtime/docker/commands.rs
@@ -217,6 +217,7 @@ pub fn get_container_config_from_executor_config(
             runtime: runtime.map(|s| s.to_string()),
             memory: exec_config.resource_limits.memory_limit_bytes,
             log_config: log_config.cloned(),
+            network_mode: exec_config.network_name.map(|n| n.to_string()),
             cpu_period: exec_config
                 .resource_limits
                 .cpu_period
@@ -325,6 +326,7 @@ mod tests {
 
         let mut exec_config = DockerExecutorConfig::from_image_with_defaults(String::default());
         exec_config.mount = mount;
+        exec_config.network_name = Some("my-network".to_string());
 
         get_container_config_from_executor_config(
             &backend_name,

--- a/plane/src/types/mod.rs
+++ b/plane/src/types/mod.rs
@@ -230,6 +230,7 @@ pub struct DockerExecutorConfig {
     #[serde(default)]
     pub resource_limits: ResourceLimits,
     pub mount: Option<Mount>,
+    pub network_name: Option<String>,
 }
 
 impl DockerExecutorConfig {
@@ -241,6 +242,7 @@ impl DockerExecutorConfig {
             resource_limits: ResourceLimits::default(),
             credentials: None,
             mount: None,
+            network_name: None,
         }
     }
 }


### PR DESCRIPTION
This adds a way to pass a network name in a spawn config. This is mostly useful for development.