### PR TITLE
Mark backend as terminated when lost

### DIFF
--- a/plane/src/drone/backend_manager.rs
+++ b/plane/src/drone/backend_manager.rs
@@ -195,7 +195,7 @@ impl<R: Runtime> BackendManager<R> {
                             .terminate(&backend_id, termination == TerminationKind::Hard)
                             .await
                         {
-                            Ok(()) => break,
+                            Ok(_) => break,
                             Err(err) => {
                                 tracing::error!(?err, "failed to terminate backend");
                                 backoff.wait().await;

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -107,7 +107,7 @@ impl<R: Runtime> Executor<R> {
                 let mut success = false;
                 for attempt in 1..=10 {
                     match runtime.terminate(&backend_id, true).await {
-                        Ok(()) => {
+                        Ok(_) => {
                             success = true;
                             break;
                         }
@@ -211,6 +211,9 @@ impl<R: Runtime> Executor<R> {
                     // else we can deadlock.
                     let Some(manager) = self.backends.get(backend_id) else {
                         tracing::warn!(backend_id = backend_id.as_value(), "Backend not found when handling terminate action (assumed terminated).");
+
+                        // Terminate will only return an error on a docker error, not if the backend is already terminated.
+                        self.runtime.terminate(backend_id, true).await?;
 
                         self.state_store
                             .lock()

--- a/plane/src/drone/runtime/mod.rs
+++ b/plane/src/drone/runtime/mod.rs
@@ -29,11 +29,14 @@ pub trait Runtime: Send + Sync + 'static {
         static_token: Option<&BearerToken>,
     ) -> impl Future<Output = Result<SpawnResult, Error>> + Send;
 
+    /// Attempts to terminate the backend. If `hard` is true, the runtime should make every effort
+    /// to forcibly terminate the backend immediately; otherwise it should invoke graceful shutdown.
+    /// If the backend is already terminated or does not exist, this should return `Ok(false)`.
     fn terminate(
         &self,
         backend_id: &BackendName,
         hard: bool,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
 
     /// Provides a callback to be called when the executor has a new metrics message for
     /// any backend.


### PR DESCRIPTION
In the weird case where the Plane controller asks a drone to terminate a backend that has already been removed from Docker, we currently do nothing but don't do anything to tell the controller to mark the backend as lost. This changes the behavior to do that, via the state store.