### PR TITLE
Refactor of 743

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,6 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -42,7 +42,6 @@ tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread", "signal"]
 tokio-rustls = "0.24.1"
 tokio-stream = { version="0.1.14", features=["sync"] }
 tokio-tungstenite = { version = "0.20.1", features = ["rustls-tls-webpki-roots"] }
-tokio-util = "0.7.10"
 tower-http = { version = "0.4.4", features = ["trace", "cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "valuable"] }

--- a/plane/src/typed_unix_socket/mod.rs
+++ b/plane/src/typed_unix_socket/mod.rs
@@ -248,8 +248,8 @@ mod tests {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-        // Simulate client restart
-        client.shutdown();
+        // Simulate new client connection
+        drop(client);
         let client = TypedUnixSocketClient::<String, String>::new(&socket_path)
             .await
             .unwrap();
@@ -275,7 +275,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         // Simulate server restart
-        server.shutdown();
+        drop(server);
         let server = TypedUnixSocketServer::<String, String>::new(&socket_path)
             .await
             .unwrap();

--- a/plane/src/typed_unix_socket/server.rs
+++ b/plane/src/typed_unix_socket/server.rs
@@ -1,3 +1,5 @@
+use crate::util::GuardHandle;
+
 use super::{get_quick_backoff, WrappedMessage};
 use anyhow::Error;
 use serde::{Deserialize, Serialize};
@@ -5,13 +7,13 @@ use std::{
     fmt::Debug,
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
     net::{UnixListener, UnixStream},
     sync::broadcast,
 };
-use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
 pub struct TypedUnixSocketServer<MessageToServer, MessageToClient>
@@ -23,7 +25,7 @@ where
     event_tx: broadcast::Sender<MessageToServer>,
     request_tx: broadcast::Sender<WrappedMessage<MessageToServer>>,
     response_tx: broadcast::Sender<WrappedMessage<MessageToClient>>,
-    shutdown_token: CancellationToken,
+    loop_task: Arc<GuardHandle>,
 }
 
 impl<MessageToServer, MessageToClient> TypedUnixSocketServer<MessageToServer, MessageToClient>
@@ -40,15 +42,13 @@ where
         let (event_tx, _) = broadcast::channel(100);
         let (request_tx, _) = broadcast::channel(100);
         let (response_tx, _) = broadcast::channel(100);
-        let shutdown_token = CancellationToken::new();
 
-        tokio::spawn({
+        let loop_task = {
             let event_tx = event_tx.clone();
             let request_tx = request_tx.clone();
             let response_tx = response_tx.clone();
             let response_rx = response_tx.subscribe(); // ensure we subscribe synchronously to avoid issues sending messages
-            let shutdown_token = shutdown_token.clone();
-            async move {
+            GuardHandle::new(async move {
                 let mut response_rx = response_rx; // we're doing this so that we can re-subscribe at the end of the loop for successive iterations
                 loop {
                     match listener.accept().await {
@@ -58,7 +58,6 @@ where
                                 event_tx.clone(),
                                 request_tx.clone(),
                                 response_rx,
-                                shutdown_token.clone(),
                             )
                             .await
                             .is_ok()
@@ -74,15 +73,15 @@ where
                     }
                     response_rx = response_tx.subscribe();
                 }
-            }
-        });
+            })
+        };
 
         Ok(Self {
             socket_path,
             event_tx,
             request_tx,
             response_tx,
-            shutdown_token,
+            loop_task: Arc::new(loop_task),
         })
     }
 
@@ -112,13 +111,17 @@ where
         self.response_tx.send(message_msg)?;
         Ok(())
     }
+}
 
-    pub fn shutdown(&self) {
-        // Signal the handler to shut down
-        self.shutdown_token.cancel();
-
+impl<MessageToServer, MessageToClient> Drop
+    for TypedUnixSocketServer<MessageToServer, MessageToClient>
+where
+    MessageToServer: Send + Sync + 'static + Clone + Debug + Serialize + for<'de> Deserialize<'de>,
+    MessageToClient: Send + Sync + 'static + Clone + Debug + Serialize + for<'de> Deserialize<'de>,
+{
+    fn drop(&mut self) {
         if let Err(e) = fs::remove_file(&self.socket_path) {
-            tracing::warn!("Failed to remove socket file: {}", e);
+            tracing::error!("Error removing socket file: {}", e);
         }
     }
 }
@@ -128,7 +131,6 @@ async fn handle_connection<MessageToServer, MessageToClient>(
     event_tx: broadcast::Sender<MessageToServer>,
     request_tx: broadcast::Sender<WrappedMessage<MessageToServer>>,
     mut response_rx: broadcast::Receiver<WrappedMessage<MessageToClient>>,
-    shutdown_token: CancellationToken,
 ) -> Result<(), anyhow::Error>
 where
     MessageToServer: Send + Sync + 'static + Clone + Debug + Serialize + for<'de> Deserialize<'de>,
@@ -144,46 +146,39 @@ where
     // Task to handle receiving messages
     let recv_task = {
         let event_tx = event_tx.clone();
-        let shutdown_token = shutdown_token.clone();
         async move {
             loop {
-                tokio::select! {
-                    _ = shutdown_token.cancelled() => {
-                        tracing::info!("Shutting down receive task");
-                        break;
-                    }
-                    result = lines.next_line() => {
-                        match result {
-                            Ok(Some(line)) => {
-                                let msg: WrappedMessage<MessageToServer> = match serde_json::from_str(&line) {
-                                    Ok(msg) => msg,
-                                    Err(e) => {
-                                        tracing::error!("Error deserializing message: {}", e);
-                                        continue;
-                                    }
-                                };
-                                match msg {
-                                    WrappedMessage { id: Some(_), .. } => {
-                                        if let Err(e) = request_tx.send(msg) {
-                                            tracing::error!("Error sending request: {}", e);
-                                        }
-                                    }
-                                    WrappedMessage { id: None, message } => {
-                                        if let Err(e) = event_tx.send(message) {
-                                            tracing::error!("Error sending event: {}", e);
-                                        }
-                                    }
+                let result = lines.next_line().await;
+                match result {
+                    Ok(Some(line)) => {
+                        let msg: WrappedMessage<MessageToServer> = match serde_json::from_str(&line)
+                        {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                tracing::error!("Error deserializing message: {}", e);
+                                continue;
+                            }
+                        };
+                        match msg {
+                            WrappedMessage { id: Some(_), .. } => {
+                                if let Err(e) = request_tx.send(msg) {
+                                    tracing::error!("Error sending request: {}", e);
                                 }
                             }
-                            Ok(None) => {
-                                tracing::info!("Connection closed by client");
-                                return Err(anyhow::anyhow!("Connection closed by server"));
-                            }
-                            Err(e) => {
-                                tracing::error!("Error reading line: {}", e);
-                                return Err(anyhow::anyhow!("Error reading line: {}", e));
+                            WrappedMessage { id: None, message } => {
+                                if let Err(e) = event_tx.send(message) {
+                                    tracing::error!("Error sending event: {}", e);
+                                }
                             }
                         }
+                    }
+                    Ok(None) => {
+                        tracing::info!("Connection closed by client");
+                        return Err(anyhow::anyhow!("Connection closed by server"));
+                    }
+                    Err(e) => {
+                        tracing::error!("Error reading line: {}", e);
+                        return Err(anyhow::anyhow!("Error reading line: {}", e));
                     }
                 }
             }
@@ -193,38 +188,30 @@ where
 
     // Task to handle sending responses
     let send_task = {
-        let shutdown_token = shutdown_token.clone();
         async move {
             loop {
-                tokio::select! {
-                    _ = shutdown_token.cancelled() => {
-                        tracing::info!("Shutting down send task");
-                        break;
-                    }
-                    result = response_rx.recv() => {
-                        match result {
-                            Ok(response) => {
-                                let response_str = match serde_json::to_string(&response) {
-                                    Ok(response_str) => response_str,
-                                    Err(e) => {
-                                        tracing::error!("Error serializing response: {}", e);
-                                        continue;
-                                    }
-                                };
-                                if let Err(e) = writer.write_all(response_str.as_bytes()).await {
-                                    tracing::error!("Error writing response: {}", e);
-                                }
-                                if let Err(e) = writer.write_all(b"\n").await {
-                                    tracing::error!("Error writing newline: {}", e);
-                                }
-                                if let Err(e) = writer.flush().await {
-                                    tracing::error!("Error flushing writer: {}", e);
-                                }
-                            }
+                let result = response_rx.recv().await;
+                match result {
+                    Ok(response) => {
+                        let response_str = match serde_json::to_string(&response) {
+                            Ok(response_str) => response_str,
                             Err(e) => {
-                                tracing::error!("Error receiving response: {}", e);
+                                tracing::error!("Error serializing response: {}", e);
+                                continue;
                             }
+                        };
+                        if let Err(e) = writer.write_all(response_str.as_bytes()).await {
+                            tracing::error!("Error writing response: {}", e);
                         }
+                        if let Err(e) = writer.write_all(b"\n").await {
+                            tracing::error!("Error writing newline: {}", e);
+                        }
+                        if let Err(e) = writer.flush().await {
+                            tracing::error!("Error flushing writer: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Error receiving response: {}", e);
                     }
                 }
             }


### PR DESCRIPTION
This is a further refactoring of #743:

- removes dependency on `tokio-util`
- avoids unnecessary `tokio::spawn`s (which can make it hard to reason about behavior) and uses `GuardHandle` to ensure that send/recv loops are terminated when a client/server is dropped
- replaces shutdown handlers with `Drop` impl