### PR TITLE
Warn on key registered, not error

### DIFF
--- a/plane/src/drone/mod.rs
+++ b/plane/src/drone/mod.rs
@@ -120,7 +120,7 @@ pub async fn drone_loop<R: Runtime>(
                             .register_key(backend_id.clone(), key.clone());
 
                         if !result {
-                            tracing::error!(
+                            tracing::warn!(
                                 backend = backend_id.as_value(),
                                 "Key already registered for backend. Ignoring spawn request."
                             );


### PR DESCRIPTION
This can happen if the message sent by the server was not acknowledged by the drone. It's not actionable, but should be unusual and may be a hint if other things are broken, so demote it to a warning.