### PR TITLE
Create a BackendStatus -> numeric mapping

### DIFF
--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -40,6 +40,8 @@ impl BackendStatus {
     /// Returns an integer representation of the status. This is meant to be an
     /// opaque value that can be used for determining if one status comes before
     /// another in the backend lifecycle.
+    /// Gaps are intentionally left in these values to provide room for future
+    /// statuses.
     fn as_int(&self) -> i32 {
         match self {
             BackendStatus::Scheduled => 10,

--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -36,6 +36,23 @@ pub enum BackendStatus {
     Terminated,
 }
 
+impl BackendStatus {
+    /// Returns an integer representation of the status. This is meant to be an
+    /// opaque value that can be used for determining if one status comes before
+    /// another in the backend lifecycle.
+    fn as_int(&self) -> i32 {
+        match self {
+            BackendStatus::Scheduled => 10,
+            BackendStatus::Loading => 20,
+            BackendStatus::Starting => 30,
+            BackendStatus::Waiting => 40,
+            BackendStatus::Ready => 50,
+            BackendStatus::Terminating => 60,
+            BackendStatus::Terminated => 70,
+        }
+    }
+}
+
 impl valuable::Valuable for BackendStatus {
     fn as_value(&self) -> valuable::Value {
         match self {
@@ -228,6 +245,10 @@ impl BackendState {
             BackendState::Terminating { .. } => BackendStatus::Terminating,
             BackendState::Terminated { .. } => BackendStatus::Terminated,
         }
+    }
+
+    pub fn status_int(&self) -> i32 {
+        self.status().as_int()
     }
 
     pub fn to_loading(&self) -> BackendState {


### PR DESCRIPTION
The backend status lifecycle has a strict ordering. Backends can move forward in the lifecycle, but not backwards.

On the Rust side, `BackendStatus` is `PartialOrd`, so we can do natural comparisons between backend statuses as they relate to this order. However, on the database side, they are just strings.

We would like to add constraints at the database level, such as "a backend status can never go backwards". In the database, statuses are represented as strings. We could re-implement the comparison logic in the database as a function over strings, but I don't love having the logic live in both Rust and the database.

The alternative implemented here is to create a function from `BackendStatus` -> `i32` which produces a number that reflects the natural order of statuses.

No Plane behavior is changed in this PR. The next step is to do a migration that stores these numbers alongside the status.