### PR TITLE
query for drones from drone pool with a duration

### DIFF
--- a/plane/.sqlx/query-051c7989e10af66145582f52eeddaebef2b8b92dee44f74c35545491f98ea1f5.json
+++ b/plane/.sqlx/query-051c7989e10af66145582f52eeddaebef2b8b92dee44f74c35545491f98ea1f5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n                drone.id as id,\n                drone.ready as ready,\n                drone.draining as draining,\n                drone.last_heartbeat as \"last_heartbeat!\",\n                drone.last_local_time as \"last_local_time!\",\n                drone.pool as pool,\n                node.name as name,\n                node.cluster as \"cluster!\",\n                node.plane_version as plane_version,\n                node.plane_hash as plane_hash,\n                node.controller as \"controller!\",\n                node.last_connection_start_time as \"last_connection_start_time!\"\n            from node\n            left join drone on node.id = drone.id\n            where\n                drone.ready = true\n                and controller is not null\n                and cluster = $1\n                and now() - drone.last_heartbeat < $2\n                and pool = $3\n                and last_local_time is not null\n                and last_connection_start_time is not null\n            order by drone.id\n            ",
+  "query": "\n            select\n                drone.id as id,\n                drone.ready as ready,\n                drone.draining as draining,\n                drone.last_heartbeat as \"last_heartbeat!\",\n                drone.last_local_time as \"last_local_time!\",\n                drone.pool as pool,\n                node.name as name,\n                node.cluster as \"cluster!\",\n                node.plane_version as plane_version,\n                node.plane_hash as plane_hash,\n                node.controller as \"controller!\",\n                node.last_connection_start_time as \"last_connection_start_time!\"\n            from node\n            left join drone on node.id = drone.id\n            where\n                drone.ready = true\n                and controller is not null\n                and cluster = $1\n                and now() - drone.last_heartbeat < $2\n                and pool = $3\n                and last_local_time is not null\n                and last_connection_start_time is not null\n            order by drone.id desc\n            limit 100\n            ",
   "describe": {
     "columns": [
       {
@@ -86,5 +86,5 @@
       true
     ]
   },
-  "hash": "ef01a24414ba72a6761389476f82f16cde67bf0183dc6a67d4178c6051f14f1f"
+  "hash": "051c7989e10af66145582f52eeddaebef2b8b92dee44f74c35545491f98ea1f5"
 }

--- a/plane/src/database/drone.rs
+++ b/plane/src/database/drone.rs
@@ -95,6 +95,8 @@ impl<'a> DroneDatabase<'a> {
         Ok(result.pool.into())
     }
 
+    /// Returns a list of drones that are ready and have been seen in the last `seen_in_last` duration.
+    /// Limits the result to the most recent 100 drones.
     pub async fn get_drones_for_pool(
         &self,
         cluster: &ClusterName,


### PR DESCRIPTION
Updates the `get_drones_for_pool()` to take a duration instead of only returning drones from the last 45 seconds. This flexibility is useful when wanting to see all the drones that ran over a longer period of time.