### PR TITLE
Fix proxy panic

### DIFF
--- a/plane/src/proxy/proxy_service.rs
+++ b/plane/src/proxy/proxy_service.rs
@@ -203,9 +203,17 @@ impl RequestHandler {
                 return Err(ProxyError::MissingHostHeader);
             };
 
+            let host = match host.parse() {
+                Ok(host) => host,
+                Err(err) => {
+                    tracing::warn!(?err, ?host, "Invalid host header.");
+                    return Err(ProxyError::BadRequest);
+                }
+            };
+
             let mut uri_parts = req.uri().clone().into_parts();
             uri_parts.scheme = Some("https".parse().expect("https is a valid scheme."));
-            uri_parts.authority = Some(host.parse().expect("HOST header is a valid authority."));
+            uri_parts.authority = Some(host);
             uri_parts.path_and_query = uri_parts
                 .path_and_query
                 .or_else(|| Some(PathAndQuery::from_static("")));

--- a/plane/src/proxy/route_map.rs
+++ b/plane/src/proxy/route_map.rs
@@ -107,6 +107,7 @@ impl RouteMap {
             .push(token.clone(), route_info);
         let listener_lock = self.listeners.lock().expect("Listeners lock was poisoned.");
         if let Some(listener_lock) = listener_lock.get(&token) {
+            // We are just using the watch channel as a signal; this will ensure that anyone listening on `.changed()` resolves.
             listener_lock.send_modify(|()| ());
         };
     }


### PR DESCRIPTION
We have occasionally seen a panic in the proxy where the receiver falls behind. This fixes that by replacing the broadcast channel with a watch channel, since we don't need to keep multiple values around anyway.