### PR TITLE
Check DB in healthcheck

### DIFF
--- a/plane/.sqlx/query-822ae07d4783158bc1912bb623e5107cc9002d519e1143a9c200ed6ee18b6d0f.json
+++ b/plane/.sqlx/query-822ae07d4783158bc1912bb623e5107cc9002d519e1143a9c200ed6ee18b6d0f.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "select 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "822ae07d4783158bc1912bb623e5107cc9002d519e1143a9c200ed6ee18b6d0f"
+}

--- a/plane/src/database/mod.rs
+++ b/plane/src/database/mod.rs
@@ -88,6 +88,13 @@ impl PlaneDatabase {
         ControllerDatabase::new(&self.pool)
     }
 
+    pub async fn health_check(&self) -> Result<(), sqlx::Error> {
+        sqlx::query_scalar!("select 1")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     pub async fn connect(
         &self,
         default_cluster: Option<&ClusterName>,


### PR DESCRIPTION
Tested locally:
```bash
$ ./dev/postgres.sh && ./dev/controller.sh
$ curl http://localhost:8080/ctrl/status
{"status":"ok","version":"0.4.12","hash":"c4c10be0"}

$ docker stop postgres
$ curl http://localhost:8080/ctrl/status
{"id":"k1deo8tjiowthy","kind":"Other","message":"Database health check failed"}
```

Note: The status endpoint actually hangs until the default 30 second timeout before outputting this response. This is ok because kubernetes enforces an automatic 1 second timeout on health checks before assuming they're failing.