### PR TITLE
Proxy waits on (scheduled/loading/starting) backend to become ready

### DIFF
--- a/plane/.sqlx/query-40f7fcd5f76e4af0d795a0174322388656ca9868c614462380066d457b4b0b15.json
+++ b/plane/.sqlx/query-40f7fcd5f76e4af0d795a0174322388656ca9868c614462380066d457b4b0b15.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            select\n                backend_id,\n                username,\n                auth,\n                cluster,\n                last_status,\n                cluster_address,\n                secret_token,\n                subdomain\n            from token\n            inner join backend\n            on backend.id = token.backend_id\n            and backend.last_status = $2\n            where token = $1\n            limit 1\n            ",
+  "query": "\n            select\n                backend_id,\n                username,\n                auth,\n                cluster,\n                last_status,\n                cluster_address,\n                secret_token,\n                subdomain\n            from token\n            inner join backend\n            on backend.id = token.backend_id\n            where token = $1\n            limit 1\n            ",
   "describe": {
     "columns": [
       {
@@ -46,7 +46,6 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Text"
       ]
     },
@@ -61,5 +60,5 @@
       true
     ]
   },
-  "hash": "40cab83a74ad43beb3c150f6f14496cfe9fbe4a7a2253bc38da68cc31007d318"
+  "hash": "40f7fcd5f76e4af0d795a0174322388656ca9868c614462380066d457b4b0b15"
 }

--- a/plane/src/client/sse.rs
+++ b/plane/src/client/sse.rs
@@ -220,9 +220,8 @@ mod tests {
 
         let stream = stream! {
             loop {
-                match timeout(Duration::from_millis(100), receiver.recv()).await {
-                    Ok(_) => break,
-                    Err(_) => ()
+                if let Ok(_) = timeout(Duration::from_millis(100), receiver.recv()).await {
+                    break;
                 };
 
                 let event = Event::default().json_data(&Count { value }).unwrap().id(value.to_string());

--- a/plane/src/controller/proxy.rs
+++ b/plane/src/controller/proxy.rs
@@ -112,21 +112,6 @@ pub async fn handle_route_info_request(
 
                     match payload {
                         BackendState::Ready { address } => {
-                            let Some(address) = address else {
-                                tracing::error!("Received Ready notification without address");
-                                let response = RouteInfoResponse {
-                                    token,
-                                    route_info: None,
-                                };
-                                if let Err(err) = socket.send(response) {
-                                    tracing::error!(
-                                        ?err,
-                                        "Error sending route info response to proxy."
-                                    );
-                                }
-                                break;
-                            };
-
                             let route_info = partial_route_info.set_address(address);
                             let response = RouteInfoResponse {
                                 token,

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -402,7 +402,7 @@ impl<'a> BackendDatabase<'a> {
             .map_err(|_| sqlx::Error::Decode("Failed to decode backend name.".into()))?;
         let partial = PartialRouteInfo {
             backend_id: backend_id.clone(),
-            secret_token: SecretToken::from("".to_string()),
+            secret_token: SecretToken::from(result.secret_token),
             cluster: ClusterName::from_str(&result.cluster)
                 .map_err(|_| sqlx::Error::Decode("Failed to decode cluster name.".into()))?,
             user: None,

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -293,7 +293,7 @@ impl<'a> BackendDatabase<'a> {
     pub async fn route_info_for_static_token(
         &self,
         token: &BearerToken,
-    ) -> sqlx::Result<Option<RouteInfo>> {
+    ) -> sqlx::Result<RouteInfoResult> {
         let result = sqlx::query!(
             r#"
             select
@@ -312,39 +312,54 @@ impl<'a> BackendDatabase<'a> {
         .await?;
 
         let Some(result) = result else {
-            return Ok(None);
+            return Ok(RouteInfoResult::NotFound);
         };
 
-        let Some(address) = result.cluster_address else {
-            return Ok(None);
+        let ready = match result.last_status.as_str() {
+            "ready" => true,
+            "terminated" | "terminating" => {
+                return Ok(RouteInfoResult::NotFound);
+            }
+            _ => false,
         };
 
-        let Ok(address) = address.parse::<SocketAddr>() else {
-            tracing::warn!("Invalid cluster address: {}", address);
-            return Ok(None);
-        };
+        let backend_id = BackendName::try_from(result.id)
+            .map_err(|_| sqlx::Error::Decode("Failed to decode backend name.".into()))?;
 
-        Ok(Some(RouteInfo {
-            backend_id: BackendName::try_from(result.id)
-                .map_err(|_| sqlx::Error::Decode("Failed to decode backend name.".into()))?,
-            address: BackendAddr(address),
+        let partial = PartialRouteInfo {
+            backend_id: backend_id.clone(),
             secret_token: SecretToken::from("".to_string()),
-            user: None,
-            user_data: None,
             cluster: ClusterName::from_str(&result.cluster)
                 .map_err(|_| sqlx::Error::Decode("Failed to decode cluster name.".into()))?,
+            user: None,
+            user_data: None,
             subdomain: result
                 .subdomain
                 .map(Subdomain::try_from)
                 .transpose()
                 .map_err(|e| sqlx::Error::Decode(e.into()))?,
-        }))
+        };
+
+        if !ready {
+            return Ok(RouteInfoResult::Waiting(partial));
+        }
+
+        let Some(address) = result.cluster_address else {
+            tracing::warn!(%backend_id, "Backend marked as ready, but no cluster address found.");
+            return Ok(RouteInfoResult::NotFound);
+        };
+
+        let Ok(address) = address.parse::<SocketAddr>() else {
+            tracing::warn!("Invalid cluster address: {}", address);
+            return Ok(RouteInfoResult::NotFound);
+        };
+
+        Ok(RouteInfoResult::Ready(
+            partial.set_address(BackendAddr(address)),
+        ))
     }
 
-    pub async fn route_info_for_token(
-        &self,
-        token: &BearerToken,
-    ) -> sqlx::Result<Option<RouteInfo>> {
+    pub async fn route_info_for_token(&self, token: &BearerToken) -> sqlx::Result<RouteInfoResult> {
         if token.is_static() {
             return self.route_info_for_static_token(token).await;
         }
@@ -363,44 +378,59 @@ impl<'a> BackendDatabase<'a> {
             from token
             inner join backend
             on backend.id = token.backend_id
-            and backend.last_status = $2
             where token = $1
             limit 1
             "#,
             token.to_string(),
-            BackendStatus::Ready.to_string(),
         )
         .fetch_optional(&self.db.pool)
         .await?;
 
         let Some(result) = result else {
-            return Ok(None);
+            return Ok(RouteInfoResult::NotFound);
         };
 
-        let Some(address) = result.cluster_address else {
-            return Ok(None);
+        let ready = match result.last_status.as_str() {
+            "ready" => true,
+            "terminated" | "terminating" => {
+                return Ok(RouteInfoResult::NotFound);
+            }
+            _ => false,
         };
 
-        let Ok(address) = address.parse::<SocketAddr>() else {
-            tracing::warn!("Invalid cluster address: {}", address);
-            return Ok(None);
-        };
-
-        Ok(Some(RouteInfo {
-            backend_id: BackendName::try_from(result.backend_id)
-                .map_err(|_| sqlx::Error::Decode("Failed to decode backend name.".into()))?,
-            address: BackendAddr(address),
-            secret_token: SecretToken::from(result.secret_token),
-            user: result.username,
-            user_data: Some(result.auth),
+        let backend_id = BackendName::try_from(result.backend_id)
+            .map_err(|_| sqlx::Error::Decode("Failed to decode backend name.".into()))?;
+        let partial = PartialRouteInfo {
+            backend_id: backend_id.clone(),
+            secret_token: SecretToken::from("".to_string()),
             cluster: ClusterName::from_str(&result.cluster)
                 .map_err(|_| sqlx::Error::Decode("Failed to decode cluster name.".into()))?,
+            user: None,
+            user_data: None,
             subdomain: result
                 .subdomain
                 .map(Subdomain::try_from)
                 .transpose()
                 .map_err(|e| sqlx::Error::Decode(e.into()))?,
-        }))
+        };
+
+        if !ready {
+            return Ok(RouteInfoResult::Waiting(partial));
+        }
+
+        let Some(address) = result.cluster_address else {
+            tracing::warn!(%backend_id, "Backend marked as ready, but no cluster address found.");
+            return Ok(RouteInfoResult::NotFound);
+        };
+
+        let Ok(address) = address.parse::<SocketAddr>() else {
+            tracing::warn!(address, %backend_id, "Invalid cluster address.");
+            return Ok(RouteInfoResult::NotFound);
+        };
+
+        Ok(RouteInfoResult::Ready(
+            partial.set_address(BackendAddr(address)),
+        ))
     }
 
     pub async fn update_keepalive(&self, backend_id: &BackendName) -> sqlx::Result<()> {
@@ -598,4 +628,33 @@ pub async fn emit_state_change(
     emit_with_key(txn, &backend.to_string(), new_state).await?;
 
     Ok(())
+}
+
+pub enum RouteInfoResult {
+    NotFound,
+    Waiting(PartialRouteInfo),
+    Ready(RouteInfo),
+}
+
+pub struct PartialRouteInfo {
+    pub backend_id: BackendName,
+    secret_token: SecretToken,
+    cluster: ClusterName,
+    user: Option<String>,
+    user_data: Option<serde_json::Value>,
+    subdomain: Option<Subdomain>,
+}
+
+impl PartialRouteInfo {
+    pub fn set_address(self, address: BackendAddr) -> RouteInfo {
+        RouteInfo {
+            backend_id: self.backend_id,
+            address,
+            secret_token: self.secret_token,
+            user: self.user,
+            user_data: self.user_data,
+            cluster: self.cluster,
+            subdomain: self.subdomain,
+        }
+    }
 }

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -341,7 +341,7 @@ impl<'a> BackendDatabase<'a> {
         };
 
         if !ready {
-            return Ok(RouteInfoResult::Waiting(partial));
+            return Ok(RouteInfoResult::Pending(partial));
         }
 
         let Some(address) = result.cluster_address else {
@@ -354,7 +354,7 @@ impl<'a> BackendDatabase<'a> {
             return Ok(RouteInfoResult::NotFound);
         };
 
-        Ok(RouteInfoResult::Ready(
+        Ok(RouteInfoResult::Available(
             partial.set_address(BackendAddr(address)),
         ))
     }
@@ -415,7 +415,7 @@ impl<'a> BackendDatabase<'a> {
         };
 
         if !ready {
-            return Ok(RouteInfoResult::Waiting(partial));
+            return Ok(RouteInfoResult::Pending(partial));
         }
 
         let Some(address) = result.cluster_address else {
@@ -428,7 +428,7 @@ impl<'a> BackendDatabase<'a> {
             return Ok(RouteInfoResult::NotFound);
         };
 
-        Ok(RouteInfoResult::Ready(
+        Ok(RouteInfoResult::Available(
             partial.set_address(BackendAddr(address)),
         ))
     }
@@ -632,8 +632,12 @@ pub async fn emit_state_change(
 
 pub enum RouteInfoResult {
     NotFound,
-    Waiting(PartialRouteInfo),
-    Ready(RouteInfo),
+
+    /// The route is not yet available, because the backend is starting.
+    Pending(PartialRouteInfo),
+
+    /// The route info is available, and the backend is ready or terminated.
+    Available(RouteInfo),
 }
 
 pub struct PartialRouteInfo {


### PR DESCRIPTION
Follows design doc here: https://docs.google.com/document/d/1KpZMyz8E4a7pk_OaIqQKLWWKiLo4SdRhe1MkUy6EyLE/edit

The general approach:
- Introduces [`PartialRouteInfo`](https://github.com/jamsocket/plane/pull/772/files#diff-0abc0d77e47c302d2447792802d4fb6300e2ee6ba14b99cb00016febdc5109e3R639-R660), which is a `RouteInfo` without an address. The address is not known until the scheduled drone sets it when the backend is in the `Starting` state, but everything else in the `RouteInfo` is _always_ available on a valid (non-expired) connection token. A `PartialRouteInfo` [can be upgraded](https://github.com/jamsocket/plane/pull/772/files#diff-0abc0d77e47c302d2447792802d4fb6300e2ee6ba14b99cb00016febdc5109e3R649-R659) to a regular `RouteInfo` once the address is known.
- Introduces [`RouteInfoResult`](https://github.com/jamsocket/plane/pull/772/files#diff-0abc0d77e47c302d2447792802d4fb6300e2ee6ba14b99cb00016febdc5109e3R633-R637) which is an enum corresponding to the three possible states of a backend:
  1. Not found (connection token expired or never existed)
  2. Waiting (corresponds to scheduled/loading/starting/waiting states)
  3. Ready
- Refactors [`route_info_for_token`](https://github.com/jamsocket/plane/pull/772/files#diff-0abc0d77e47c302d2447792802d4fb6300e2ee6ba14b99cb00016febdc5109e3R362) (and relatedly [`route_info_for_static_token`](https://github.com/jamsocket/plane/pull/772/files#diff-0abc0d77e47c302d2447792802d4fb6300e2ee6ba14b99cb00016febdc5109e3R293) to return a `RouteInfoResult`. This also means modifying the query to return a result even if the backend is not ready.

In the controller:
- Adds [`handle_route_info_request`](https://github.com/jamsocket/plane/pull/772/files#diff-79359c831293eaad21a8f2cf49450fc80fa43b0888bb741868703fce8c0d2e80R25), which uses `route_info_for_token` and then, if the result is a `RouteInfoResult::Waiting`, [spawns a tokio task to listen for backend changes](https://github.com/jamsocket/plane/pull/772/files#diff-79359c831293eaad21a8f2cf49450fc80fa43b0888bb741868703fce8c0d2e80R73).

