### PR TITLE
Remove generics

### DIFF
--- a/plane/src/drone/key_manager.rs
+++ b/plane/src/drone/key_manager.rs
@@ -1,4 +1,4 @@
-use super::{executor::Executor, runtime::Runtime};
+use super::executor::Executor;
 use crate::{
     log_types::LoggableTime,
     names::BackendName,
@@ -12,8 +12,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::sleep;
 use valuable::Valuable;
 
-pub struct KeyManager<R: Runtime> {
-    executor: Arc<Executor<R>>,
+pub struct KeyManager {
+    executor: Arc<Executor>,
 
     /// Map from a backend to the most recently acquired key for that backend,
     /// along with the handle for the task that is responsible for renewing the key
@@ -23,11 +23,11 @@ pub struct KeyManager<R: Runtime> {
     sender: Option<TypedSocketSender<RenewKeyRequest>>,
 }
 
-async fn renew_key_loop<R: Runtime>(
+async fn renew_key_loop(
     key: AcquiredKey,
     backend: BackendName,
     sender: Option<TypedSocketSender<RenewKeyRequest>>,
-    executor: Arc<Executor<R>>,
+    executor: Arc<Executor>,
 ) {
     loop {
         let now = Utc::now();
@@ -111,8 +111,8 @@ async fn renew_key_loop<R: Runtime>(
     }
 }
 
-impl<R: Runtime> KeyManager<R> {
-    pub fn new(executor: Arc<Executor<R>>) -> Self {
+impl KeyManager {
+    pub fn new(executor: Arc<Executor>) -> Self {
         Self {
             executor,
             handles: HashMap::new(),

--- a/plane/src/drone/runtime/docker/mod.rs
+++ b/plane/src/drone/runtime/docker/mod.rs
@@ -164,9 +164,6 @@ async fn events_loop(
 
 #[async_trait::async_trait]
 impl Runtime for DockerRuntime {
-    // type RuntimeConfig = DockerRuntimeConfig;
-    // type BackendConfig = DockerExecutorConfig;
-
     async fn prepare(&self, config: &serde_json::Value) -> Result<()> {
         let config: DockerExecutorConfig = serde_json::from_value(config.clone())?;
         let image = &config.image;

--- a/plane/src/drone/runtime/mod.rs
+++ b/plane/src/drone/runtime/mod.rs
@@ -7,7 +7,6 @@ use crate::{
 use anyhow::Error;
 use docker::{SpawnResult, TerminateEvent};
 use futures_util::Stream;
-use serde::{de::DeserializeOwned, Serialize};
 use std::{net::SocketAddr, pin::Pin};
 
 pub mod docker;
@@ -16,15 +15,12 @@ pub mod unix_socket;
 
 #[async_trait::async_trait]
 pub trait Runtime: Send + Sync + 'static {
-    type RuntimeConfig;
-    type BackendConfig: Clone + Send + Sync + 'static + DeserializeOwned + Serialize;
-
-    async fn prepare(&self, config: &Self::BackendConfig) -> Result<(), Error>;
+    async fn prepare(&self, config: &serde_json::Value) -> Result<(), Error>;
 
     async fn spawn(
         &self,
         backend_id: &BackendName,
-        executable: Self::BackendConfig,
+        executable: &serde_json::Value,
         acquired_key: Option<&AcquiredKey>,
         static_token: Option<&BearerToken>,
     ) -> Result<SpawnResult, Error>;

--- a/plane/src/drone/runtime/unix_socket/mod.rs
+++ b/plane/src/drone/runtime/unix_socket/mod.rs
@@ -48,9 +48,6 @@ pub struct UnixSocketRuntimeConfig {
 
 #[async_trait::async_trait]
 impl Runtime for UnixSocketRuntime {
-    // type RuntimeConfig = UnixSocketRuntimeConfig;
-    // type BackendConfig = DockerExecutorConfig;
-
     async fn prepare(&self, config: &serde_json::Value) -> Result<()> {
         let config: DockerExecutorConfig = serde_json::from_value(config.clone())?;
 


### PR DESCRIPTION
Basically, removes generics everywhere we use them in favor of boxing.

One of the changes here is to do the parsing of executor / backend configs inside the implementation instead of outside. This is necessary if we want to actually use runtimes dynamically, since we won't always know the type we want to parse.

I haven't tested that this works, but it compiles.