### PR TITLE
Make ready address required

### DIFF
--- a/plane/src/drone/backend_manager.rs
+++ b/plane/src/drone/backend_manager.rs
@@ -178,7 +178,7 @@ impl<R: Runtime> BackendManager<R> {
                             TerminationReason::StartupTimeout,
                         )
                     } else {
-                        state.to_ready()
+                        state.to_ready(address)
                     }
                 })
             }

--- a/plane/src/drone/state_store.rs
+++ b/plane/src/drone/state_store.rs
@@ -258,7 +258,7 @@ mod test {
             .register_event(
                 &backend_id,
                 &BackendState::Ready {
-                    address: Some(dummy_addr()),
+                    address: dummy_addr(),
                 },
                 Utc::now(),
             )
@@ -268,7 +268,7 @@ mod test {
         assert_eq!(
             result,
             BackendState::Ready {
-                address: Some(dummy_addr())
+                address: dummy_addr()
             }
         );
     }
@@ -280,7 +280,7 @@ mod test {
         let backend_id = BackendName::new_random();
 
         let ready_state = BackendState::Ready {
-            address: Some(dummy_addr()),
+            address: dummy_addr(),
         };
         {
             state_store
@@ -291,7 +291,7 @@ mod test {
             assert_eq!(
                 result,
                 BackendState::Ready {
-                    address: Some(dummy_addr())
+                    address: dummy_addr()
                 }
             );
         }
@@ -333,7 +333,7 @@ mod test {
         let backend_id = BackendName::new_random();
 
         let ready_state = BackendState::Ready {
-            address: Some(dummy_addr()),
+            address: dummy_addr(),
         };
         state_store
             .register_event(&backend_id, &ready_state, Utc::now())
@@ -348,7 +348,7 @@ mod test {
             assert_eq!(
                 event.state,
                 BackendState::Ready {
-                    address: Some(dummy_addr())
+                    address: dummy_addr()
                 }
             );
         }
@@ -391,7 +391,7 @@ mod test {
         let backend_id = BackendName::new_random();
 
         let ready_state = BackendState::Ready {
-            address: Some(dummy_addr()),
+            address: dummy_addr(),
         };
         state_store
             .register_event(&backend_id, &ready_state, Utc::now())
@@ -418,7 +418,7 @@ mod test {
             assert_eq!(
                 event.state,
                 BackendState::Ready {
-                    address: Some(dummy_addr())
+                    address: dummy_addr()
                 }
             );
         }
@@ -453,7 +453,7 @@ mod test {
             assert_eq!(
                 event.state,
                 BackendState::Ready {
-                    address: Some(dummy_addr())
+                    address: dummy_addr()
                 }
             );
         }

--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -90,7 +90,7 @@ pub enum BackendState {
         address: BackendAddr,
     },
     Ready {
-        address: Option<BackendAddr>,
+        address: BackendAddr,
     },
     Terminating {
         last_status: BackendStatus,
@@ -234,7 +234,7 @@ impl BackendState {
     pub fn address(&self) -> Option<BackendAddr> {
         match self {
             BackendState::Waiting { address } => Some(*address),
-            BackendState::Ready { address } => *address,
+            BackendState::Ready { address } => Some(*address),
             _ => None,
         }
     }
@@ -271,12 +271,10 @@ impl BackendState {
 
     pub fn to_ready(&self) -> BackendState {
         match self {
-            BackendState::Waiting { address } => BackendState::Ready {
-                address: Some(*address),
-            },
+            BackendState::Waiting { address } => BackendState::Ready { address: *address },
             _ => {
-                tracing::warn!("to_ready called on non-waiting backend");
-                BackendState::Ready { address: None }
+                tracing::error!("to_ready called on non-waiting backend");
+                self.clone()
             }
         }
     }

--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -269,14 +269,8 @@ impl BackendState {
         }
     }
 
-    pub fn to_ready(&self) -> BackendState {
-        match self {
-            BackendState::Waiting { address } => BackendState::Ready { address: *address },
-            _ => {
-                tracing::error!("to_ready called on non-waiting backend");
-                self.clone()
-            }
-        }
+    pub fn to_ready(&self, address: BackendAddr) -> BackendState {
+        BackendState::Ready { address }
     }
 
     pub fn to_terminating(


### PR DESCRIPTION
It doesn't make sense to have a ready backend without an address. This avoids that situation by passing the address through `to_ready`.

`BackendState` is sent across the network, so changes to it need to be version-safe. This change is version-safe:

- If a **writer** is on this version and a **reader** is on a prior version, nothing bad can happen. The reader continues to accept `null` a the value, but the writer will never produce that value.
- If a **reader** is on this version and a **writer** is on a prior version, there is technically a code path that produces a `null` here, but:
  - It's an error code path, and it logs a warning message
  - I could not find any instances of this in our logs
