### PR TITLE
Introduce SocketPath type with copy-safe drop

### DIFF
--- a/plane/src/typed_unix_socket/mod.rs
+++ b/plane/src/typed_unix_socket/mod.rs
@@ -1,6 +1,8 @@
 use crate::util::ExponentialBackoff;
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
 
 pub mod client;
 pub mod server;
@@ -20,6 +22,16 @@ fn get_quick_backoff() -> ExponentialBackoff {
         1.1,
         Duration::milliseconds(100),
     )
+}
+
+pub struct SocketPath(pub PathBuf);
+
+impl Drop for SocketPath {
+    fn drop(&mut self) {
+        if let Err(e) = fs::remove_file(&self.0) {
+            tracing::error!("Error removing socket file: {}", e);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We want `server` to be copy safe: we do this successfully by wrapping the `_loop_task` in an `Arc` `GuardHandle`. However, `server`'s `Drop` will attempt to delete the `socket_path` file on every dropped copy -- which isn't the behavior we want. We only want that file deleted when the last copy is dropped. We achieve this similar to `_loop_task`: by creating a new `SocketPath` type (with its own `Drop` impl) and wrapping this type in an `Arc`.