### PR TITLE
Allow drone to run as unix domain socket executor

### DIFF
--- a/plane/plane-tests/tests/metrics.rs
+++ b/plane/plane-tests/tests/metrics.rs
@@ -9,6 +9,7 @@ use plane::{
     types::DockerExecutorConfig,
 };
 use plane_test_macro::plane_test;
+use serde_json::json;
 
 mod common;
 
@@ -18,19 +19,20 @@ async fn test_get_metrics(_: TestEnvironment) {
         .await
         .unwrap();
 
-    let executor_config =
-        DockerExecutorConfig::from_image_with_defaults("ghcr.io/jamsocket/demo-image-drop-four");
+    let executor_config = json!(DockerExecutorConfig::from_image_with_defaults(
+        "ghcr.io/jamsocket/demo-image-drop-four"
+    ));
 
     runtime.prepare(&executor_config).await.unwrap();
     let (send, mut recv) = tokio::sync::mpsc::channel(1);
-    runtime.metrics_callback(move |metrics_message| {
+    runtime.metrics_callback(Box::new(move |metrics_message| {
         send.try_send(metrics_message).unwrap();
-    });
+    }));
 
     let backend_name = BackendName::new_random();
 
     runtime
-        .spawn(&backend_name, executor_config, None, None)
+        .spawn(&backend_name, &executor_config, None, None)
         .await
         .unwrap();
 

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -1,3 +1,4 @@
+use super::{runtime::unix_socket::UnixSocketRuntimeConfig, ExecutorConfig};
 use crate::{
     drone::{runtime::docker::DockerRuntimeConfig, DroneConfig},
     names::{DroneName, OrRandom},
@@ -9,8 +10,6 @@ use chrono::Duration;
 use clap::Parser;
 use std::{net::IpAddr, path::PathBuf};
 use url::Url;
-
-use super::{runtime::unix_socket::UnixSocketRuntimeConfig, ExecutorConfig};
 
 #[derive(Parser)]
 pub struct DroneOpts {
@@ -34,7 +33,7 @@ pub struct DroneOpts {
     #[clap(long)]
     docker_runtime: Option<String>,
 
-    // Optional path to a unix socket for connecting to an external executor.
+    /// Optional path to a unix socket for connecting to an external executor.
     #[clap(long)]
     executor_socket: Option<PathBuf>,
 

--- a/plane/src/drone/command.rs
+++ b/plane/src/drone/command.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use std::{net::IpAddr, path::PathBuf};
 use url::Url;
 
-use super::ExecutorConfig;
+use super::{runtime::unix_socket::UnixSocketRuntimeConfig, ExecutorConfig};
 
 #[derive(Parser)]
 pub struct DroneOpts {
@@ -33,6 +33,10 @@ pub struct DroneOpts {
 
     #[clap(long)]
     docker_runtime: Option<String>,
+
+    // Optional path to a unix socket for connecting to an external executor.
+    #[clap(long)]
+    executor_socket: Option<PathBuf>,
 
     /// Optional log driver configuration, passed to Docker as the `LogConfig` field.
     #[clap(long)]
@@ -71,12 +75,16 @@ impl DroneOpts {
             Duration::try_seconds(self.auto_prune_containers_older_than_seconds as i64)
                 .expect("valid duration");
 
-        let docker_config = DockerRuntimeConfig {
-            runtime: self.docker_runtime,
-            log_config,
-            mount_base: self.mount_base,
-            auto_prune: Some(self.auto_prune_images),
-            cleanup_min_age: Some(cleanup_min_age),
+        let executor_config = if let Some(socket_path) = self.executor_socket {
+            ExecutorConfig::UnixSocket(UnixSocketRuntimeConfig { socket_path })
+        } else {
+            ExecutorConfig::Docker(DockerRuntimeConfig {
+                runtime: self.docker_runtime,
+                log_config,
+                mount_base: self.mount_base,
+                auto_prune: Some(self.auto_prune_images),
+                cleanup_min_age: Some(cleanup_min_age),
+            })
         };
 
         let ip: IpAddr = resolve_hostname(&self.ip)
@@ -93,7 +101,7 @@ impl DroneOpts {
             auto_prune: None,      // deprecated
             cleanup_min_age: None, // deprecated
             docker_config: None,   // deprecated
-            executor_config: Some(ExecutorConfig::Docker(docker_config)),
+            executor_config: Some(executor_config),
         };
 
         Ok(drone_config)

--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -16,17 +16,17 @@ use std::{
 };
 use valuable::Valuable;
 
-pub struct Executor<R: Runtime> {
-    pub runtime: Arc<R>,
+pub struct Executor {
+    pub runtime: Arc<Box<dyn Runtime>>,
     state_store: Arc<Mutex<StateStore>>,
-    backends: Arc<DashMap<BackendName, Arc<BackendManager<R>>>>,
+    backends: Arc<DashMap<BackendName, Arc<BackendManager>>>,
     ip: IpAddr,
     _backend_event_listener: GuardHandle,
 }
 
-impl<R: Runtime> Executor<R> {
-    pub async fn new(runtime: Arc<R>, state_store: StateStore, ip: IpAddr) -> Self {
-        let backends: Arc<DashMap<BackendName, Arc<BackendManager<R>>>> = Arc::default();
+impl Executor {
+    pub async fn new(runtime: Arc<Box<dyn Runtime>>, state_store: StateStore, ip: IpAddr) -> Self {
+        let backends: Arc<DashMap<BackendName, Arc<BackendManager>>> = Arc::default();
         let state_store = Arc::new(Mutex::new(state_store));
 
         #[allow(clippy::unwrap_used)]
@@ -39,7 +39,7 @@ impl<R: Runtime> Executor<R> {
             let backends = backends.clone();
 
             GuardHandle::new(async move {
-                let mut events = Box::pin(docker.events());
+                let mut events = docker.events();
                 while let Some(event) = events.next().await {
                     if let Some((_, manager)) = backends.remove(&event.backend_id) {
                         tracing::info!(
@@ -71,7 +71,7 @@ impl<R: Runtime> Executor<R> {
     // This prevents bugs where an agent restart leaves the drone unable to
     // terminate old backends.
     async fn terminate_preexisting_backends(
-        runtime: Arc<R>,
+        runtime: Arc<Box<dyn Runtime>>,
         state_store: Arc<Mutex<StateStore>>,
     ) -> Result<()> {
         let backends = state_store
@@ -188,11 +188,9 @@ impl<R: Runtime> Executor<R> {
                     }
                 };
 
-                let backend_config: R::BackendConfig = serde_json::from_value(executable.clone())?;
-
                 let manager = BackendManager::new(
                     backend_id.clone(),
-                    backend_config,
+                    executable.clone(),
                     BackendState::default(),
                     self.runtime.clone(),
                     callback,

--- a/plane/src/drone/key_manager.rs
+++ b/plane/src/drone/key_manager.rs
@@ -1,4 +1,4 @@
-use super::{executor::Executor, runtime::Runtime};
+use super::executor::Executor;
 use crate::{
     log_types::LoggableTime,
     names::BackendName,
@@ -12,8 +12,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::sleep;
 use valuable::Valuable;
 
-pub struct KeyManager<R: Runtime> {
-    executor: Arc<Executor<R>>,
+pub struct KeyManager {
+    executor: Arc<Executor>,
 
     /// Map from a backend to the most recently acquired key for that backend,
     /// along with the handle for the task that is responsible for renewing the key
@@ -23,11 +23,11 @@ pub struct KeyManager<R: Runtime> {
     sender: Option<TypedSocketSender<RenewKeyRequest>>,
 }
 
-async fn renew_key_loop<R: Runtime>(
+async fn renew_key_loop(
     key: AcquiredKey,
     backend: BackendName,
     sender: Option<TypedSocketSender<RenewKeyRequest>>,
-    executor: Arc<Executor<R>>,
+    executor: Arc<Executor>,
 ) {
     loop {
         let now = Utc::now();
@@ -111,8 +111,8 @@ async fn renew_key_loop<R: Runtime>(
     }
 }
 
-impl<R: Runtime> KeyManager<R> {
-    pub fn new(executor: Arc<Executor<R>>) -> Self {
+impl KeyManager {
+    pub fn new(executor: Arc<Executor>) -> Self {
         Self {
             executor,
             handles: HashMap::new(),

--- a/plane/src/drone/runtime/docker/mod.rs
+++ b/plane/src/drone/runtime/docker/mod.rs
@@ -22,7 +22,7 @@ use bollard::{
 };
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, pin::Pin};
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
@@ -162,11 +162,10 @@ async fn events_loop(
     }
 }
 
+#[async_trait::async_trait]
 impl Runtime for DockerRuntime {
-    type RuntimeConfig = DockerRuntimeConfig;
-    type BackendConfig = DockerExecutorConfig;
-
-    async fn prepare(&self, config: &DockerExecutorConfig) -> Result<()> {
+    async fn prepare(&self, config: &serde_json::Value) -> Result<()> {
+        let config: DockerExecutorConfig = serde_json::from_value(config.clone())?;
         let image = &config.image;
         let credentials = config
             .credentials
@@ -188,10 +187,11 @@ impl Runtime for DockerRuntime {
     async fn spawn(
         &self,
         backend_id: &BackendName,
-        executable: DockerExecutorConfig,
+        executable: &serde_json::Value,
         acquired_key: Option<&AcquiredKey>,
         static_token: Option<&BearerToken>,
     ) -> Result<SpawnResult> {
+        let executable: DockerExecutorConfig = serde_json::from_value(executable.clone())?;
         let container_id =
             run_container(self, backend_id, executable, acquired_key, static_token).await?;
         let port = get_port(&self.docker, &container_id).await?;
@@ -246,17 +246,19 @@ impl Runtime for DockerRuntime {
         }
     }
 
-    fn events(&self) -> impl Stream<Item = TerminateEvent> {
-        BroadcastStream::new(self.events_sender.subscribe()).filter_map(|e| match e {
-            Ok(e) => Some(e),
-            Err(e) => {
-                tracing::error!(?e, "Error receiving Docker event.");
-                None
-            }
-        })
+    fn events(&self) -> Pin<Box<dyn Stream<Item = TerminateEvent> + Send>> {
+        Box::pin(
+            BroadcastStream::new(self.events_sender.subscribe()).filter_map(|e| match e {
+                Ok(e) => Some(e),
+                Err(e) => {
+                    tracing::error!(?e, "Error receiving Docker event.");
+                    None
+                }
+            }),
+        )
     }
 
-    fn metrics_callback<F: Fn(BackendMetricsMessage) + Send + Sync + 'static>(&self, sender: F) {
+    fn metrics_callback(&self, sender: Box<dyn Fn(BackendMetricsMessage) + Send + Sync + 'static>) {
         let mut lock = self
             .metrics_callback
             .lock()

--- a/plane/src/drone/runtime/mod.rs
+++ b/plane/src/drone/runtime/mod.rs
@@ -6,49 +6,39 @@ use crate::{
 };
 use anyhow::Error;
 use docker::{SpawnResult, TerminateEvent};
-use futures_util::{Future, Stream};
-use serde::{de::DeserializeOwned, Serialize};
-use std::net::SocketAddr;
+use futures_util::Stream;
+use std::{net::SocketAddr, pin::Pin};
 
 pub mod docker;
 #[allow(unused)] // for now, to disable clippy noise
 pub mod unix_socket;
 
+#[async_trait::async_trait]
 pub trait Runtime: Send + Sync + 'static {
-    type RuntimeConfig;
-    type BackendConfig: Clone + Send + Sync + 'static + DeserializeOwned + Serialize;
+    async fn prepare(&self, config: &serde_json::Value) -> Result<(), Error>;
 
-    fn prepare(
-        &self,
-        config: &Self::BackendConfig,
-    ) -> impl Future<Output = Result<(), Error>> + Send;
-
-    fn spawn(
+    async fn spawn(
         &self,
         backend_id: &BackendName,
-        executable: Self::BackendConfig,
+        executable: &serde_json::Value,
         acquired_key: Option<&AcquiredKey>,
         static_token: Option<&BearerToken>,
-    ) -> impl Future<Output = Result<SpawnResult, Error>> + Send;
+    ) -> Result<SpawnResult, Error>;
 
     /// Attempts to terminate the backend. If `hard` is true, the runtime should make every effort
     /// to forcibly terminate the backend immediately; otherwise it should invoke graceful shutdown.
     /// If the backend is already terminated or does not exist, this should return `Ok(false)`.
-    fn terminate(
-        &self,
-        backend_id: &BackendName,
-        hard: bool,
-    ) -> impl Future<Output = Result<bool, Error>> + Send;
+    async fn terminate(&self, backend_id: &BackendName, hard: bool) -> Result<bool, Error>;
 
     /// Provides a callback to be called when the executor has a new metrics message for
     /// any backend.
-    fn metrics_callback<F: Fn(BackendMetricsMessage) + Send + Sync + 'static>(&self, sender: F);
+    fn metrics_callback(&self, sender: Box<dyn Fn(BackendMetricsMessage) + Send + Sync + 'static>);
 
-    fn events(&self) -> impl Stream<Item = TerminateEvent> + Send;
+    fn events(&self) -> Pin<Box<dyn Stream<Item = TerminateEvent> + Send>>;
 
-    fn wait_for_backend(
+    async fn wait_for_backend(
         &self,
         backend: &BackendName,
         address: SocketAddr,
-    ) -> impl Future<Output = Result<(), BackendError>> + Send;
+    ) -> Result<(), BackendError>;
 }


### PR DESCRIPTION
Example usage:
```bash
$ ./dev/drone.sh --executor-socket "/tmp/tmp.sock"
```

This includes work from @paulgb to remove generics (#774) in favor of `Box<dyn ...>>` to enable dynamic dispatch.