### PR TITLE
Add batching to cleanup loop and clean up backend_key also

### DIFF
--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -103,6 +103,7 @@ impl TestEnvironment {
             url,
             None,
             None,
+            100,
         )
         .await
         .expect("Unable to construct controller.")

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -103,7 +103,7 @@ impl TestEnvironment {
             url,
             None,
             None,
-            100,
+            None,
         )
         .await
         .expect("Unable to construct controller.")

--- a/plane/src/bin/db-cli.rs
+++ b/plane/src/bin/db-cli.rs
@@ -45,9 +45,8 @@ enum Command {
         #[clap(long)]
         min_age_days: Option<i32>,
 
-        /// The number of rows to delete in a single batch.
-        #[clap(long, default_value = "100")]
-        cleanup_batch_size: i32,
+        /// The number of rows to delete in a single batch (uses a default value if not provided).
+        cleanup_batch_size: Option<i32>,
     },
     MarkBackendLost {
         #[arg(required = true)]

--- a/plane/src/bin/db-cli.rs
+++ b/plane/src/bin/db-cli.rs
@@ -44,6 +44,10 @@ enum Command {
         /// If not provided, only expired tokens will be removed, and other data will be retained.
         #[clap(long)]
         min_age_days: Option<i32>,
+
+        /// The number of rows to delete in a single batch.
+        #[clap(long, default_value = "100")]
+        cleanup_batch_size: i32,
     },
     MarkBackendLost {
         #[arg(required = true)]
@@ -234,8 +238,11 @@ async fn main_inner(opts: Opts) -> anyhow::Result<()> {
                 println!("No such drone: {} on {}", drone, cluster);
             }
         }
-        Command::Cleanup { min_age_days } => {
-            plane::cleanup::run_cleanup(&db, min_age_days).await?;
+        Command::Cleanup {
+            min_age_days,
+            cleanup_batch_size,
+        } => {
+            plane::cleanup::run_cleanup(&db, min_age_days, cleanup_batch_size).await?;
         }
     };
 

--- a/plane/src/cleanup.rs
+++ b/plane/src/cleanup.rs
@@ -1,18 +1,22 @@
 use crate::database::{subscribe::EventSubscriptionManager, PlaneDatabase};
 use anyhow::Result;
 
-const CLEANUP_LOOP_INTERVAL_SECONDS: u64 = 60 * 15;
+const CLEANUP_LOOP_INTERVAL_SECONDS: u64 = 60 * 3;
+const DEFAULT_BATCH_SIZE: i32 = 100;
 
 pub async fn run_cleanup(
     db: &PlaneDatabase,
     min_age_days: Option<i32>,
-    cleanup_batch_size: i32,
+    cleanup_batch_size: Option<i32>,
 ) -> Result<()> {
     tracing::info!("Running cleanup");
 
     if let Some(min_age_days) = min_age_days {
         db.backend()
-            .cleanup(min_age_days, cleanup_batch_size)
+            .cleanup(
+                min_age_days,
+                cleanup_batch_size.unwrap_or(DEFAULT_BATCH_SIZE),
+            )
             .await?;
         EventSubscriptionManager::clean_up_events(&db.pool, min_age_days).await?;
     }
@@ -27,7 +31,7 @@ pub async fn run_cleanup(
 pub async fn run_cleanup_loop(
     db: PlaneDatabase,
     min_age_days: Option<i32>,
-    cleanup_batch_size: i32,
+    cleanup_batch_size: Option<i32>,
 ) {
     // Each controller runs a cleanup loop. To avoid having them all run at the same time, we
     // introduce a random offset to the start time.

--- a/plane/src/cleanup.rs
+++ b/plane/src/cleanup.rs
@@ -3,11 +3,17 @@ use anyhow::Result;
 
 const CLEANUP_LOOP_INTERVAL_SECONDS: u64 = 60 * 15;
 
-pub async fn run_cleanup(db: &PlaneDatabase, min_age_days: Option<i32>) -> Result<()> {
+pub async fn run_cleanup(
+    db: &PlaneDatabase,
+    min_age_days: Option<i32>,
+    cleanup_batch_size: i32,
+) -> Result<()> {
     tracing::info!("Running cleanup");
 
     if let Some(min_age_days) = min_age_days {
-        db.backend().cleanup(min_age_days).await?;
+        db.backend()
+            .cleanup(min_age_days, cleanup_batch_size)
+            .await?;
         EventSubscriptionManager::clean_up_events(&db.pool, min_age_days).await?;
     }
 
@@ -18,14 +24,18 @@ pub async fn run_cleanup(db: &PlaneDatabase, min_age_days: Option<i32>) -> Resul
     Ok(())
 }
 
-pub async fn run_cleanup_loop(db: PlaneDatabase, min_age_days: Option<i32>) {
+pub async fn run_cleanup_loop(
+    db: PlaneDatabase,
+    min_age_days: Option<i32>,
+    cleanup_batch_size: i32,
+) {
     // Each controller runs a cleanup loop. To avoid having them all run at the same time, we
     // introduce a random offset to the start time.
     let random_offset_seconds = rand::random::<u64>() % CLEANUP_LOOP_INTERVAL_SECONDS;
     tokio::time::sleep(tokio::time::Duration::from_secs(random_offset_seconds)).await;
 
     loop {
-        if let Err(e) = run_cleanup(&db, min_age_days).await {
+        if let Err(e) = run_cleanup(&db, min_age_days, cleanup_batch_size).await {
             tracing::error!("Error running cleanup: {:?}", e);
         }
 

--- a/plane/src/controller/command.rs
+++ b/plane/src/controller/command.rs
@@ -48,6 +48,7 @@ impl ControllerOpts {
             controller_url,
             default_cluster: self.default_cluster,
             cleanup_min_age_days: self.cleanup_min_age_days,
+            cleanup_batch_size: 100,
         })
     }
 }

--- a/plane/src/controller/command.rs
+++ b/plane/src/controller/command.rs
@@ -48,7 +48,7 @@ impl ControllerOpts {
             controller_url,
             default_cluster: self.default_cluster,
             cleanup_min_age_days: self.cleanup_min_age_days,
-            cleanup_batch_size: 100,
+            cleanup_batch_size: None,
         })
     }
 }

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -165,7 +165,7 @@ impl ControllerServer {
         controller_url: Url,
         default_cluster: Option<ClusterName>,
         cleanup_min_age_days: Option<i32>,
-        cleanup_batch_size: i32,
+        cleanup_batch_size: Option<i32>,
     ) -> Result<Self> {
         let bind_addr = listener.local_addr()?;
 
@@ -312,12 +312,7 @@ pub struct ControllerConfig {
     pub controller_url: Url,
     pub default_cluster: Option<ClusterName>,
     pub cleanup_min_age_days: Option<i32>,
-    #[serde(default = "default_cleanup_batch_size")]
-    pub cleanup_batch_size: i32,
-}
-
-fn default_cleanup_batch_size() -> i32 {
-    100
+    pub cleanup_batch_size: Option<i32>,
 }
 
 pub async fn run_controller(config: ControllerConfig) -> Result<()> {


### PR DESCRIPTION
- Adds batching (default size 100).
- Sets the interval to once every 3 minutes (per controller) instead of once every 15 minutes
- Cleans up `backend_key` table too (as long as the keys are expired. This should always be the case, but we fail-safe by not deleting a non-expired key.)