### PR TITLE
Satisfy clippy

### DIFF
--- a/plane/plane-tests/tests/common/docker.rs
+++ b/plane/plane-tests/tests/common/docker.rs
@@ -112,11 +112,8 @@ impl Container {
 
         while let Some(next) = stream.next().await {
             let chunk = next?;
-            match chunk {
-                LogOutput::StdOut { message } => {
-                    stdout_buffer.extend(message);
-                }
-                _ => {}
+            if let LogOutput::StdOut { message } = chunk {
+                stdout_buffer.extend(message);
             }
         }
 

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -16,8 +16,9 @@ use plane::{
 use std::{
     net::{IpAddr, Ipv4Addr},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
+use tokio::sync::Mutex;
 use tracing::subscriber::DefaultGuard;
 use tracing_appender::non_blocking::WorkerGuard;
 use url::Url;
@@ -58,16 +59,16 @@ impl TestEnvironment {
     pub async fn cleanup(&self) {
         // Stop the log subscription before dumping the database
         // (otherwise, it logs a bunch of things that are not related to the test.)
-        self.log_subscription.lock().unwrap().take();
+        self.log_subscription.lock().await.take();
 
         // Dump the database.
-        if let Some(db) = self.db.lock().unwrap().take() {
+        if let Some(db) = self.db.lock().await.take() {
             db.drop_future().await.unwrap();
         }
 
         // Drop anything that registered a future.
         let new_drop_futures = {
-            let mut drop_futures_lock = self.drop_futures.lock().unwrap();
+            let mut drop_futures_lock = self.drop_futures.lock().await;
             std::mem::take(&mut *drop_futures_lock)
         };
 
@@ -77,7 +78,7 @@ impl TestEnvironment {
     }
 
     pub async fn db(&mut self) -> PlaneDatabase {
-        let mut db_lock = self.db.lock().unwrap();
+        let mut db_lock = self.db.lock().await;
         if db_lock.is_none() {
             let db = DevDatabase::start(self)
                 .await
@@ -183,7 +184,7 @@ impl TestEnvironment {
 
     pub async fn pebble(&mut self, dns_port: u16) -> Arc<Pebble> {
         let pebble = Arc::new(Pebble::new(self, dns_port, None).await.unwrap());
-        self.drop_futures.lock().unwrap().push(pebble.clone());
+        self.drop_futures.lock().await.push(pebble.clone());
         pebble
     }
 
@@ -197,7 +198,7 @@ impl TestEnvironment {
                 .await
                 .unwrap(),
         );
-        self.drop_futures.lock().unwrap().push(pebble.clone());
+        self.drop_futures.lock().await.push(pebble.clone());
         pebble
     }
 }

--- a/plane/src/client/sse.rs
+++ b/plane/src/client/sse.rs
@@ -220,7 +220,7 @@ mod tests {
 
         let stream = stream! {
             loop {
-                if let Ok(_) = timeout(Duration::from_millis(100), receiver.recv()).await {
+                if (timeout(Duration::from_millis(100), receiver.recv()).await).is_ok() {
                     break;
                 };
 


### PR DESCRIPTION
The only nontrivial change was switching from `std::sync::Mutex` to `tokio::sync::Mutex` because the mutex was held across calls to `.await`, following the [official guidance from Tokio](https://tokio.rs/tokio/tutorial/shared-state#on-using-stdsyncmutex-and-tokiosyncmutex).