### PR TITLE
Cache clippy check

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,6 +15,9 @@ jobs:
             components: 
             target: wasm32-unknown-unknown
             override: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Caches so we don't download the same deps every PR just to run clippy check.