### PR TITLE
Expose docker utils for re-use

### DIFF
--- a/plane/plane-tests/tests/docker_command.rs
+++ b/plane/plane-tests/tests/docker_command.rs
@@ -103,7 +103,7 @@ async fn test_resource_limits() {
     }
 
     let mut config = get_container_config_from_executor_config(
-        &backend_name,
+        Some(&backend_name),
         executor_config.clone(),
         None,
         None,

--- a/plane/src/drone/runtime/docker/mod.rs
+++ b/plane/src/drone/runtime/docker/mod.rs
@@ -64,7 +64,7 @@ pub struct DockerRuntimeConfig {
 pub type MetricsCallback = Box<dyn Fn(BackendMetricsMessage) + Send + Sync + 'static>;
 
 pub struct DockerRuntime {
-    docker: Docker,
+    pub docker: Docker,
     config: DockerRuntimeConfig,
     metrics_callback: Arc<Mutex<Option<MetricsCallback>>>,
     events_sender: Sender<TerminateEvent>,


### PR DESCRIPTION
Two things:
1. Allow me to access `docker` under the hood of the `DockerRuntime` to do custom stuff in a separate runtime. I still want to keep `DockerRuntime` around because some functionality is identical and it allows me to lean on the existing runtime's implementation of stuff.
2. Allow me to re-use the container config, which is by and large identical in a separate runtime -- except for the `backend_name`. Turns out it's not that hard to make that optional! 