### PR TITLE
Handle removed backend

### DIFF
--- a/plane/src/controller/proxy.rs
+++ b/plane/src/controller/proxy.rs
@@ -178,7 +178,11 @@ pub async fn handle_message_from_proxy(
             if let Err(err) = controller.db.backend().update_keepalive(&backend_id).await {
                 tracing::error!(?err, ?backend_id, ?node_id, "Error updating keepalive");
 
-                socket.send(MessageToProxy::BackendRemoved { backend: backend_id }).await?;
+                socket
+                    .send(MessageToProxy::BackendRemoved {
+                        backend: backend_id,
+                    })
+                    .await?;
             }
         }
         MessageFromProxy::CertManagerRequest(cert_manager_request) => {

--- a/plane/src/controller/proxy.rs
+++ b/plane/src/controller/proxy.rs
@@ -175,14 +175,29 @@ pub async fn handle_message_from_proxy(
             handle_route_info_request(token, controller, socket).await?;
         }
         MessageFromProxy::KeepAlive(backend_id) => {
-            if let Err(err) = controller.db.backend().update_keepalive(&backend_id).await {
-                tracing::error!(?err, ?backend_id, ?node_id, "Error updating keepalive");
+            match controller.db.backend().update_keepalive(&backend_id).await {
+                Ok(true) => (),
+                Ok(false) => {
+                    tracing::error!(
+                        ?backend_id,
+                        ?node_id,
+                        "Tried to update keepalive for non-existent backend"
+                    );
 
-                socket
-                    .send(MessageToProxy::BackendRemoved {
-                        backend: backend_id,
-                    })
-                    .await?;
+                    socket
+                        .send(MessageToProxy::BackendRemoved {
+                            backend: backend_id,
+                        })
+                        .await?;
+                }
+                Err(err) => {
+                    tracing::error!(
+                        ?err,
+                        ?backend_id,
+                        ?node_id,
+                        "Unhandled database error updating keepalive"
+                    );
+                }
             }
         }
         MessageFromProxy::CertManagerRequest(cert_manager_request) => {

--- a/plane/src/controller/proxy.rs
+++ b/plane/src/controller/proxy.rs
@@ -176,7 +176,9 @@ pub async fn handle_message_from_proxy(
         }
         MessageFromProxy::KeepAlive(backend_id) => {
             if let Err(err) = controller.db.backend().update_keepalive(&backend_id).await {
-                tracing::error!(?err, ?backend_id, "Error updating keepalive");
+                tracing::error!(?err, ?backend_id, ?node_id, "Error updating keepalive");
+
+                socket.send(MessageToProxy::BackendRemoved { backend: backend_id }).await?;
             }
         }
         MessageFromProxy::CertManagerRequest(cert_manager_request) => {

--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -433,7 +433,7 @@ impl<'a> BackendDatabase<'a> {
         ))
     }
 
-    pub async fn update_keepalive(&self, backend_id: &BackendName) -> sqlx::Result<()> {
+    pub async fn update_keepalive(&self, backend_id: &BackendName) -> sqlx::Result<bool> {
         let result = sqlx::query!(
             r#"
             update backend
@@ -447,10 +447,10 @@ impl<'a> BackendDatabase<'a> {
         .await?;
 
         if result.rows_affected() == 0 {
-            return Err(sqlx::Error::RowNotFound);
+            return Ok(false);
         }
 
-        Ok(())
+        Ok(true)
     }
 
     pub async fn publish_metrics(&self, metrics: BackendMetricsMessage) -> sqlx::Result<()> {


### PR DESCRIPTION
When a keepalive request fails because the backend has been removed, we should tell the proxy that the backend has been removed.

Fixes DIS-2106