### PR TITLE
Fix invalid token issue

### DIFF
--- a/plane/src/database/backend.rs
+++ b/plane/src/database/backend.rs
@@ -645,6 +645,7 @@ pub async fn emit_state_change(
     Ok(())
 }
 
+#[derive(Debug)]
 pub enum RouteInfoResult {
     NotFound,
 
@@ -655,6 +656,7 @@ pub enum RouteInfoResult {
     Available(RouteInfo),
 }
 
+#[derive(Debug)]
 pub struct PartialRouteInfo {
     pub backend_id: BackendName,
     secret_token: SecretToken,

--- a/plane/src/proxy/route_map.rs
+++ b/plane/src/proxy/route_map.rs
@@ -113,9 +113,7 @@ impl RouteMap {
     }
 
     pub fn receive(&self, response: RouteInfoResponse) {
-        if response.route_info.is_some() {
-            self.insert(response.token, response.route_info);
-        }
+        self.insert(response.token, response.route_info);
     }
 
     pub fn remove_backend(&self, backend: &BackendName) {


### PR DESCRIPTION
When a connection token does not exist, it was previously not being propagated to listeners (e.g. connections waiting on that route info response), which caused them to hang.