### PR TITLE
[bugfix] Prevent typed unix socket client from looping forever on failure to connect

### DIFF
--- a/plane/src/typed_unix_socket/mod.rs
+++ b/plane/src/typed_unix_socket/mod.rs
@@ -1,5 +1,3 @@
-use crate::util::ExponentialBackoff;
-use chrono::Duration;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
@@ -13,15 +11,6 @@ pub struct WrappedMessage<T> {
     /// (either as the request or the response). If it is not provided, this message is an event.
     id: Option<String>,
     pub message: T,
-}
-
-fn get_quick_backoff() -> ExponentialBackoff {
-    ExponentialBackoff::new(
-        Duration::milliseconds(10),
-        Duration::milliseconds(100),
-        1.1,
-        Duration::milliseconds(100),
-    )
 }
 
 pub struct SocketPath(pub PathBuf);


### PR DESCRIPTION
The implementation had double retry loop bug, resulting in the timeout being irrelevant. Remove the outer retry loop and actually time out after 30 seconds. 

While we're at it, tune the backoff to be more reasonable (less spammy -- now retries quickly initially, then backs off significantly and slows down to 1 rps).