### PR TITLE
Handle `BackendError::Other` in `wait_for_backend()`

### DIFF
--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -236,6 +236,7 @@ pub enum TerminationReason {
     KeyExpired,
     Lost,
     StartupTimeout,
+    ErrorWaiting,
 }
 
 impl valuable::Valuable for TerminationReason {
@@ -246,6 +247,7 @@ impl valuable::Valuable for TerminationReason {
             TerminationReason::KeyExpired => valuable::Value::String("key_expired"),
             TerminationReason::Lost => valuable::Value::String("lost"),
             TerminationReason::StartupTimeout => valuable::Value::String("startup_timeout"),
+            TerminationReason::ErrorWaiting => valuable::Value::String("error_waiting"),
         }
     }
 


### PR DESCRIPTION
https://github.com/jamsocket/plane/pull/766 introduced `BackendError::Other` as a way to handle misc errors that may occur in the `wait_for_backend()` executor function. However, the PR failed to handle that error type in `BackendManager`. As a result, spawns would succeed in spite of that error.

Introduce `TerminationReason::ErrorWaiting` and hard terminate any backend that encounters `BackendError::Other` in the `wait_for_backend()` step, logging the specifics. (Use a `match` statement to ensure future additions to the error struct get caught in this codepath during compilation.)