### PR TITLE
Rename TerminationReason::ErrorWaiting => InternalError

### DIFF
--- a/plane/src/drone/backend_manager.rs
+++ b/plane/src/drone/backend_manager.rs
@@ -205,7 +205,7 @@ impl BackendManager {
                         }
                         Err(BackendError::Other(msg)) => {
                             tracing::error!("Failed to wait for backend: {}", msg);
-                            state.to_hard_terminating(TerminationReason::ErrorWaiting)
+                            state.to_hard_terminating(TerminationReason::InternalError)
                         }
                     }
                 })

--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -236,7 +236,7 @@ pub enum TerminationReason {
     KeyExpired,
     Lost,
     StartupTimeout,
-    ErrorWaiting,
+    InternalError,
 }
 
 impl valuable::Valuable for TerminationReason {
@@ -247,7 +247,7 @@ impl valuable::Valuable for TerminationReason {
             TerminationReason::KeyExpired => valuable::Value::String("key_expired"),
             TerminationReason::Lost => valuable::Value::String("lost"),
             TerminationReason::StartupTimeout => valuable::Value::String("startup_timeout"),
-            TerminationReason::ErrorWaiting => valuable::Value::String("error_waiting"),
+            TerminationReason::InternalError => valuable::Value::String("internal_error"),
         }
     }
 


### PR DESCRIPTION
Renaming error status introduced in https://github.com/jamsocket/plane/pull/799 so that it's more user friendly.