### PR TITLE
Improve description about proxy

### DIFF
--- a/docs/pages/concepts/architecture.mdx
+++ b/docs/pages/concepts/architecture.mdx
@@ -34,8 +34,8 @@ Docker API calls locally on behalf of the controller.
 
 ## Proxy
 
-Proxies are used to route inbound traffic from outside of Plane towards the correct drone. Proxies are also
-responsible for terminating TLS connections. When they need to obtain a new certificate, they coordinate
+Proxies are used to route inbound traffic from outside of Plane towards the correct session backend on the drone.
+Proxies are also responsible for terminating TLS connections. When they need to obtain a new certificate, they coordinate
 with the controller to do so.
 
 ## DNS Server


### PR DESCRIPTION
If my understanding is correct, the proxy routes traffic to the session backend.
(Doesn’t the RouteMap manage routes on a per BearerToken basis?)

If my understanding is incorrect, please feel free to close this PR.