### PR TITLE
Allow Plane to delegate auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,6 @@ dependencies = [
  "dashmap",
  "data-encoding",
  "futures-util",
- "http 1.1.0",
  "http-body 0.4.6",
  "hyper 0.14.28",
  "lru",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "base64 0.21.7",
  "bitflags 1.3.2",
  "bytes",
@@ -245,12 +245,46 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -268,6 +302,27 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1056,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1073,7 +1128,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1129,7 +1184,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1178,7 +1233,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
@@ -1710,7 +1765,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "bollard",
  "chrono",
  "clap",
@@ -1719,6 +1774,7 @@ dependencies = [
  "data-encoding",
  "futures-util",
  "http 1.1.0",
+ "http-body 0.4.6",
  "hyper 0.14.28",
  "lru",
  "openssl",
@@ -1739,6 +1795,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1771,6 +1828,7 @@ version = "0.4.12"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.7.5",
  "bollard",
  "chrono",
  "futures-util",
@@ -1928,7 +1986,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -2569,6 +2627,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -22,6 +22,8 @@ colored = "2.0.4"
 dashmap = "5.5.3"
 data-encoding = "2.4.0"
 futures-util = "0.3.29"
+http = "1.1.0"
+http-body = "0.4.6"
 hyper = { version = "0.14.27", features = ["server"] }
 lru = "0.12.1"
 openssl = "0.10.66"
@@ -33,8 +35,8 @@ rusqlite = { version = "0.31.0", features = ["bundled", "serde_json"] }
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.0.0"
 serde = { version = "1.0.190", features = ["derive"] }
-serde_with = "3.4.0"
 serde_json = "1.0.107"
+serde_with = "3.4.0"
 sqlx = { version = "0.8.0", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "migrate", "json", "ipnetwork"] }
 thiserror = "1.0.50"
 time = "0.3.30"
@@ -42,12 +44,12 @@ tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread", "signal"]
 tokio-rustls = "0.24.1"
 tokio-stream = { version="0.1.14", features=["sync"] }
 tokio-tungstenite = { version = "0.20.1", features = ["rustls-tls-webpki-roots"] }
+tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["trace", "cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "valuable"] }
 trust-dns-server = "0.23.2"
 tungstenite = "0.20.1"
 url = { version="2.4.1", features=["serde"] }
-x509-parser = "0.15.1"
 valuable = { version = "0.1.0", features = ["derive"] }
-http = "1.1.0"
+x509-parser = "0.15.1"

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -22,7 +22,6 @@ colored = "2.0.4"
 dashmap = "5.5.3"
 data-encoding = "2.4.0"
 futures-util = "0.3.29"
-http = "1.1.0"
 http-body = "0.4.6"
 hyper = { version = "0.14.27", features = ["server"] }
 lru = "0.12.1"

--- a/plane/plane-tests/Cargo.toml
+++ b/plane/plane-tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1.74"
+axum = "0.7.5"
 bollard = "0.17.0"
 chrono = { version = "0.4.31", features = ["serde"] }
 futures-util = "0.3.29"

--- a/plane/plane-tests/tests/common/auth_mock.rs
+++ b/plane/plane-tests/tests/common/auth_mock.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use axum::{body::Body, http::Request};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::{
+    sync::Mutex,
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
@@ -98,7 +99,7 @@ impl MockAuthServer {
     /// Expect the server to have received an auth request, and returns a handle that can be used to
     /// accept or reject the request.
     pub async fn expect(&mut self) -> Result<AuthRequest> {
-        let mut waiting = self.waiting.lock().unwrap();
+        let mut waiting = self.waiting.lock().await;
         let auth_request = waiting.recv().await.unwrap();
         Ok(auth_request)
     }

--- a/plane/plane-tests/tests/common/auth_mock.rs
+++ b/plane/plane-tests/tests/common/auth_mock.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use axum::{body::Body, http::Request};
 use std::sync::{Arc, Mutex};
-use tokio::{sync::{mpsc, oneshot}, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
 use url::Url;
 
 #[allow(unused)]

--- a/plane/plane-tests/tests/common/auth_mock.rs
+++ b/plane/plane-tests/tests/common/auth_mock.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use axum::{body::Body, http::Request};
+use std::sync::{Arc, Mutex};
+use tokio::{sync::{mpsc, oneshot}, task::JoinHandle};
+use url::Url;
+
+#[allow(unused)]
+pub struct AuthRequest {
+    request: Request<Body>,
+    reply_channel: Option<oneshot::Sender<bool>>,
+}
+
+#[allow(unused)]
+impl AuthRequest {
+    fn reply(&mut self, ok: bool) {
+        let reply_channel = self
+            .reply_channel
+            .take()
+            .expect("Can only reply to an AuthRequest once");
+        reply_channel.send(ok).unwrap();
+    }
+
+    pub fn accept(&mut self) {
+        self.reply(true);
+    }
+
+    pub fn reject(&mut self) {
+        self.reply(false);
+    }
+
+    pub fn request(&self) -> &Request<Body> {
+        &self.request
+    }
+}
+
+#[allow(unused)]
+pub struct MockAuthServer {
+    handle: JoinHandle<()>,
+    waiting: Arc<Mutex<mpsc::Receiver<AuthRequest>>>,
+    url: Url,
+}
+
+#[allow(unused)]
+impl MockAuthServer {
+    pub async fn new() -> Self {
+        let (tx, rx) = mpsc::channel(1);
+        let waiting: Arc<Mutex<mpsc::Receiver<AuthRequest>>> = Arc::new(Mutex::new(rx));
+        let waiting_clone = Arc::clone(&waiting);
+
+        let app = axum::Router::new().route(
+            "/auth",
+            axum::routing::any(move |request: Request<Body>| async move {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                {
+                    let auth_request = AuthRequest {
+                        request,
+                        reply_channel: Some(reply_tx),
+                    };
+
+                    tx.send(auth_request).await.unwrap();
+                }
+
+                let is_authorized = reply_rx.await.unwrap();
+                if is_authorized {
+                    axum::http::StatusCode::OK
+                } else {
+                    axum::http::StatusCode::UNAUTHORIZED
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!(
+            "http://127.0.0.1:{}/auth",
+            listener.local_addr().unwrap().port()
+        ))
+        .unwrap();
+        let server = axum::serve(listener, app);
+
+        let handle = tokio::spawn(async move {
+            server.await.unwrap();
+        });
+
+        Self {
+            handle,
+            waiting,
+            url,
+        }
+    }
+
+    pub fn url(&self) -> Url {
+        self.url.clone()
+    }
+
+    /// Expect the server to have received an auth request, and returns a handle that can be used to
+    /// accept or reject the request.
+    pub async fn expect(&mut self) -> Result<AuthRequest> {
+        let mut waiting = self.waiting.lock().unwrap();
+        let auth_request = waiting.recv().await.unwrap();
+        Ok(auth_request)
+    }
+}
+
+impl Drop for MockAuthServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}

--- a/plane/plane-tests/tests/common/mod.rs
+++ b/plane/plane-tests/tests/common/mod.rs
@@ -4,8 +4,8 @@ use plane::{client::PlaneClient, names::BackendName, types::BackendStatus};
 use std::{panic::AssertUnwindSafe, time::Duration};
 use tokio::time::timeout;
 
-pub mod auth_mock;
 pub mod async_drop;
+pub mod auth_mock;
 pub mod docker;
 pub mod resources;
 pub mod test_env;

--- a/plane/plane-tests/tests/common/mod.rs
+++ b/plane/plane-tests/tests/common/mod.rs
@@ -4,6 +4,7 @@ use plane::{client::PlaneClient, names::BackendName, types::BackendStatus};
 use std::{panic::AssertUnwindSafe, time::Duration};
 use tokio::time::timeout;
 
+pub mod auth_mock;
 pub mod async_drop;
 pub mod docker;
 pub mod resources;

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -104,6 +104,28 @@ impl TestEnvironment {
             None,
             None,
             None,
+            None,
+        )
+        .await
+        .expect("Unable to construct controller.")
+    }
+
+    pub async fn controller_with_forward_auth(&mut self, forward_auth: &Url) -> ControllerServer {
+        let db = self.db().await;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url: Url = format!("http://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+
+        ControllerServer::run_with_listener(
+            db.clone(),
+            listener,
+            ControllerName::new_random(),
+            url,
+            None,
+            None,
+            None,
+            Some(forward_auth.clone()),
         )
         .await
         .expect("Unable to construct controller.")

--- a/plane/plane-tests/tests/forward_auth.rs
+++ b/plane/plane-tests/tests/forward_auth.rs
@@ -1,0 +1,92 @@
+use common::{auth_mock::MockAuthServer, test_env::TestEnvironment};
+use hyper::StatusCode;
+use plane::client::{PlaneClient, PlaneClientError};
+use plane_test_macro::plane_test;
+
+mod common;
+
+#[plane_test]
+async fn forward_auth_rejects(env: TestEnvironment) {
+    let mut mock_auth_server = MockAuthServer::new().await;
+    let controller = env
+        .controller_with_forward_auth(&mock_auth_server.url())
+        .await;
+    let client = controller.client();
+
+    let task = tokio::spawn(async move {
+        let a = client.status().await;
+        a
+    });
+
+    let mut req = mock_auth_server.expect().await.unwrap();
+    req.reject();
+
+    let res = task.await.unwrap();
+
+    assert!(matches!(res, Err(PlaneClientError::UnexpectedStatus(StatusCode::UNAUTHORIZED))));
+}
+
+#[plane_test]
+async fn forward_auth_accepts(env: TestEnvironment) {
+    let mut mock_auth_server = MockAuthServer::new().await;
+    let controller = env
+        .controller_with_forward_auth(&mock_auth_server.url())
+        .await;
+    let client = controller.client();
+
+    let task = tokio::spawn(async move {
+        let a = client.status().await;
+        a
+    });
+
+    let mut req = mock_auth_server.expect().await.unwrap();
+    req.accept();
+
+    let res = task.await.unwrap();
+
+    assert!(res.is_ok());
+}
+
+#[plane_test]
+async fn forward_auth_forwards_path(env: TestEnvironment) {
+    let mut mock_auth_server = MockAuthServer::new().await;
+    let controller = env
+        .controller_with_forward_auth(&mock_auth_server.url())
+        .await;
+    let client = controller.client();
+
+    tokio::spawn(async move {
+        let _ = client.status().await;
+    });
+
+    let req = mock_auth_server.expect().await.unwrap();
+    
+    let http_req = req.request();
+
+    assert_eq!(http_req.headers().get("x-original-path").unwrap(), "/status");
+}
+
+#[plane_test]
+async fn forward_auth_forwards_bearer_token(env: TestEnvironment) {
+    let mut mock_auth_server = MockAuthServer::new().await;
+    let controller = env
+        .controller_with_forward_auth(&mock_auth_server.url())
+        .await;
+
+    // set username on url
+    let mut controller_url = controller.url();
+    controller_url.set_username("test").unwrap();
+
+    let client = PlaneClient::new(controller_url);
+
+    tokio::spawn(async move {
+        let _ = client.status().await;
+    });
+
+    let req = mock_auth_server.expect().await.unwrap();
+    
+    let http_req = req.request();
+
+    assert_eq!(http_req.headers().get("authorization").unwrap(), "Bearer test");
+}
+

--- a/plane/plane-tests/tests/forward_auth.rs
+++ b/plane/plane-tests/tests/forward_auth.rs
@@ -23,7 +23,10 @@ async fn forward_auth_rejects(env: TestEnvironment) {
 
     let res = task.await.unwrap();
 
-    assert!(matches!(res, Err(PlaneClientError::UnexpectedStatus(StatusCode::UNAUTHORIZED))));
+    assert!(matches!(
+        res,
+        Err(PlaneClientError::UnexpectedStatus(StatusCode::UNAUTHORIZED))
+    ));
 }
 
 #[plane_test]
@@ -60,10 +63,13 @@ async fn forward_auth_forwards_path(env: TestEnvironment) {
     });
 
     let req = mock_auth_server.expect().await.unwrap();
-    
+
     let http_req = req.request();
 
-    assert_eq!(http_req.headers().get("x-original-path").unwrap(), "/status");
+    assert_eq!(
+        http_req.headers().get("x-original-path").unwrap(),
+        "/status"
+    );
 }
 
 #[plane_test]
@@ -84,9 +90,11 @@ async fn forward_auth_forwards_bearer_token(env: TestEnvironment) {
     });
 
     let req = mock_auth_server.expect().await.unwrap();
-    
+
     let http_req = req.request();
 
-    assert_eq!(http_req.headers().get("authorization").unwrap(), "Bearer test");
+    assert_eq!(
+        http_req.headers().get("authorization").unwrap(),
+        "Bearer test"
+    );
 }
-

--- a/plane/src/controller/command.rs
+++ b/plane/src/controller/command.rs
@@ -1,3 +1,4 @@
+use super::ControllerConfig;
 use crate::{
     names::{ControllerName, Name},
     types::ClusterName,
@@ -6,7 +7,6 @@ use anyhow::Result;
 use clap::Parser;
 use std::net::IpAddr;
 use url::Url;
-use super::ControllerConfig;
 
 #[derive(Parser)]
 pub struct ControllerOpts {

--- a/plane/src/controller/command.rs
+++ b/plane/src/controller/command.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use clap::Parser;
 use std::net::IpAddr;
 use url::Url;
-
 use super::ControllerConfig;
 
 #[derive(Parser)]
@@ -28,6 +27,13 @@ pub struct ControllerOpts {
 
     #[clap(long)]
     cleanup_min_age_days: Option<i32>,
+
+    /// HTTP(S) URL to forward /ctrl/ requests to in order to check if they are authorized.
+    /// The requests are stripped of their body and only include the original headers (and method),
+    /// plus an additional `x-original-path` header with the original path
+    /// (after stripping `/ctrl` and everything before it).
+    #[clap(long)]
+    forward_auth: Option<Url>,
 }
 
 impl ControllerOpts {
@@ -49,6 +55,7 @@ impl ControllerOpts {
             default_cluster: self.default_cluster,
             cleanup_min_age_days: self.cleanup_min_age_days,
             cleanup_batch_size: None,
+            forward_auth: self.forward_auth,
         })
     }
 }

--- a/plane/src/controller/forward_auth.rs
+++ b/plane/src/controller/forward_auth.rs
@@ -5,8 +5,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use http::StatusCode;
-use hyper::{Client, Uri};
+use hyper::{Client, StatusCode, Uri};
 use url::Url;
 
 pub fn clone_request_with_empty_body(parts: &request::Parts) -> request::Request<Body> {

--- a/plane/src/controller/forward_auth.rs
+++ b/plane/src/controller/forward_auth.rs
@@ -1,0 +1,84 @@
+use axum::{
+    body::{Body, BoxBody, Bytes},
+    extract::State,
+    http::{request, HeaderValue, Request},
+    middleware::Next,
+    response::Response,
+};
+use http::StatusCode;
+use hyper::{Client, Uri};
+use url::Url;
+
+pub fn clone_request_with_empty_body(parts: &request::Parts) -> request::Request<Body> {
+    // Copy method and URL.
+    let mut builder = request::Builder::new()
+        .method(parts.method.clone())
+        .uri(parts.uri.clone());
+
+    // Copy headers.
+    let headers = builder
+        .headers_mut()
+        .expect("Can always call headers_mut() on a new builder.");
+
+    headers.extend(parts.headers.clone());
+
+    headers.insert(
+        "x-original-path",
+        HeaderValue::from_str(parts.uri.path()).expect("Path is always valid."),
+    );
+
+    // Construct with an empty body.
+    builder
+        .body(Body::empty())
+        .expect("Request is always valid.")
+}
+
+pub async fn forward_layer<B>(
+    State(forward_url): State<Url>,
+    req: Request<B>,
+    next: Next<B>,
+) -> Response<BoxBody> {
+    let (parts, body) = req.into_parts();
+    let mut forward_req = clone_request_with_empty_body(&parts);
+    let req = Request::from_parts(parts, body);
+
+    let uri = forward_url
+        .to_string()
+        .parse::<Uri>()
+        .expect("Url should always parse as hyper Uri.");
+    *forward_req.uri_mut() = uri;
+
+    // Create a client
+    let client = Client::new();
+
+    // Forward the request
+    let forwarded_resp = client.request(forward_req).await;
+
+    let forwarded_resp = match forwarded_resp {
+        Ok(resp) => resp,
+        Err(err) => {
+            tracing::error!(?err, "Error forwarding auth.");
+            return response_helper(StatusCode::BAD_GATEWAY, b"Error forwarding auth.");
+        }
+    };
+
+    if forwarded_resp.status().is_success() {
+        next.run(req).await
+    } else {
+        response_helper(StatusCode::UNAUTHORIZED, b"Unauthorized")
+    }
+}
+
+fn response_helper(status: StatusCode, body: &'static [u8]) -> Response<BoxBody> {
+    // This is a bit ugly. There seems to be no way to construct an http_body with an axum::Error error type (?),
+    // but we can use map_err from http_body::Body to convert the hyper::error::Error to an axum::Error.
+    // Then, we need to box it up for Axum.
+    let body = http_body::Full::new(Bytes::from_static(body));
+    let body = http_body::Body::map_err(body, axum::Error::new);
+    let body: BoxBody = BoxBody::new(body);
+
+    Response::builder()
+        .status(status.as_u16())
+        .body(body)
+        .expect("Response is always valid.")
+}

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -162,6 +162,7 @@ impl ControllerServer {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_with_listener(
         db: PlaneDatabase,
         listener: TcpListener,
@@ -225,8 +226,7 @@ impl ControllerServer {
         if let Some(forward_auth_url) = forward_auth {
             tracing::info!(?forward_auth_url, "Forward auth enabled");
             let forward_url = forward_auth_url.clone();
-            control_routes =
-                control_routes.layer(from_fn_with_state(forward_url, forward_layer));
+            control_routes = control_routes.layer(from_fn_with_state(forward_url, forward_layer));
         }
 
         let cors_public = CorsLayer::new()


### PR DESCRIPTION
Adds `forward_auth` config option (name borrowed from [Caddy](https://caddyserver.com/docs/caddyfile/directives/forward_auth)). If provided, requests to `/ctrl/*` are forwarded to that URL first (after stripping the body). If that URL returns a 200, Plane proceeds; otherwise they are rejected.