### PR TITLE
Add health endpoint

### DIFF
--- a/plane/plane-tests/tests/docker_command.rs
+++ b/plane/plane-tests/tests/docker_command.rs
@@ -70,7 +70,7 @@ async fn test_resource_limits() {
     let docker = bollard::Docker::connect_with_local_defaults().unwrap();
     let backend_name = BackendName::new_random();
     let _container_id = ContainerId::from(format!("plane-test-{}", backend_name));
-    let mut executor_config = DockerExecutorConfig::from_image_with_defaults("debian:bookworm");
+    let mut executor_config = DockerExecutorConfig::from_image_with_defaults("alpine:latest");
 
     let resource_limits: ResourceLimits = serde_json::from_value(serde_json::json!( {
         "cpu_period": 1000000,

--- a/plane/plane-tests/tests/health.rs
+++ b/plane/plane-tests/tests/health.rs
@@ -1,0 +1,13 @@
+use common::test_env::TestEnvironment;
+use plane_test_macro::plane_test;
+
+mod common;
+
+#[plane_test]
+async fn controller_health_check(env: TestEnvironment) {
+    let controller = env.controller().await;
+    let client = controller.client();
+    let result = client.health_check().await;
+
+    assert!(result.is_ok());
+}

--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -194,6 +194,12 @@ impl PlaneClient {
         let cluster_state: ClusterState = authed_get(&self.client, &url).await?;
         Ok(cluster_state)
     }
+
+    pub async fn health_check(&self) -> Result<(), PlaneClientError> {
+        let url = self.controller_address.join("/pub/health");
+        self.client.get(url.url).send().await?;
+        Ok(())
+    }
 }
 
 async fn get_response<T: DeserializeOwned>(response: Response) -> Result<T, PlaneClientError> {

--- a/plane/src/controller/mod.rs
+++ b/plane/src/controller/mod.rs
@@ -78,9 +78,7 @@ pub async fn status(
     }))
 }
 
-pub async fn health(
-    State(controller): State<Controller>,
-) -> Result<Json<Value>, Response> {
+pub async fn health(State(controller): State<Controller>) -> Result<Json<Value>, Response> {
     controller
         .db
         .health_check()


### PR DESCRIPTION
We currently use `/ctrl/status` as a health check endpoint. The introduction of auth delegation (#804) applies, when enabled, to all `/ctrl` endpoints, including the health check. That means that the health checker needs to have credentials.

Instead, this adds a separate health check endpoint `/pub/health` which is part of the `/pub` path, which is not credentialed. This does not include the version information returned by the `/ctrl/status` endpoint, but does a health check.