### PR TITLE
Ensure that a process-level crypto provider exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rusqlite",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -33,6 +33,7 @@ pem = "3.0.2"
 rand = "0.8.5"
 reqwest = { version = "0.12.8", features = ["json", "rustls-tls"], default-features = false }
 rusqlite = { version = "0.32", features = ["bundled", "serde_json"] }
+rustls = "0.23.14"
 rustls-pemfile = "2.0.0"
 rustls-pki-types = "1.0.0"
 serde = { version = "1.0.190", features = ["derive"] }

--- a/plane/src/main.rs
+++ b/plane/src/main.rs
@@ -86,6 +86,8 @@ async fn main() {
 
     init_tracing();
 
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let result = run(opts).await;
     match result {
         Ok(()) => {}


### PR DESCRIPTION
`rustls` requires a process-level `CryptoProvider` be setup. We already do this in `dynamic-proxy`, which is why those tests pass, but we do not do it in Plane itself so it sometimes fails.