### PR TITLE
Remove timeout from HTTP request

### DIFF
--- a/dynamic-proxy/src/proxy.rs
+++ b/dynamic-proxy/src/proxy.rs
@@ -17,6 +17,7 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 #[derive(Clone)]
 pub struct ProxyClient {
     client: Client<HttpConnector, SimpleBody>,
+    #[allow(unused)] // TODO: implement this.
     timeout: Duration,
 }
 
@@ -108,12 +109,9 @@ impl ProxyClient {
         &self,
         request: Request<SimpleBody>,
     ) -> Result<Response<SimpleBody>, ProxyError> {
-        let res = match tokio::time::timeout(self.timeout, self.client.request(request)).await {
-            Ok(Ok(res)) => res,
-            Err(_) => {
-                return Err(ProxyError::Timeout);
-            }
-            Ok(Err(e)) => {
+        let res = match self.client.request(request).await {
+            Ok(res) => res,
+            Err(e) => {
                 return Err(ProxyError::RequestFailed(e.into()));
             }
         };

--- a/dynamic-proxy/tests/test_proxy_request.rs
+++ b/dynamic-proxy/tests/test_proxy_request.rs
@@ -9,8 +9,6 @@ use dynamic_proxy::{
 };
 use http::{Method, Request, StatusCode};
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use std::net::SocketAddr;
-use tokio::net::TcpListener;
 
 mod common;
 
@@ -116,22 +114,23 @@ async fn test_proxy_body() {
     assert_eq!(result.body, "test");
 }
 
-#[tokio::test]
-async fn test_proxy_no_upstream() {
-    let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-    let tcp_listener = TcpListener::bind(addr).await.unwrap();
-    let addr = tcp_listener.local_addr().unwrap();
+// TODO: Re-enable when timeout is re-implemented. (Paul 2024-10-11)
+// #[tokio::test]
+// async fn test_proxy_no_upstream() {
+//     let addr = SocketAddr::from(([127, 0, 0, 1], 0));
+//     let tcp_listener = TcpListener::bind(addr).await.unwrap();
+//     let addr = tcp_listener.local_addr().unwrap();
 
-    let req = Request::builder()
-        .method(Method::GET)
-        .uri(format!("http://{}", addr))
-        .body(simple_empty_body())
-        .unwrap();
+//     let req = Request::builder()
+//         .method(Method::GET)
+//         .uri(format!("http://{}", addr))
+//         .body(simple_empty_body())
+//         .unwrap();
 
-    let client = ProxyClient::new();
-    let (result, upgrade_handler) = client.request(req).await.unwrap();
+//     let client = ProxyClient::new();
+//     let (result, upgrade_handler) = client.request(req).await.unwrap();
 
-    // expect error HTTP 502 after timeout
-    assert_eq!(result.status(), StatusCode::GATEWAY_TIMEOUT);
-    assert!(upgrade_handler.is_none());
-}
+//     // expect error HTTP 502 after timeout
+//     assert_eq!(result.status(), StatusCode::GATEWAY_TIMEOUT);
+//     assert!(upgrade_handler.is_none());
+// }


### PR DESCRIPTION
In the proxy, we currently use a timeout around the entire HTTP request. This does not only capture the time to make the initial connection as intended, but also the entire time of the request, which means that large requests fail.

This removes the timeout entirely, since the HTTP client has its own timeout that is aware of the connection status.