### PR TITLE
Proxy refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
- "tower",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "tower",
  "tracing",
 ]
 

--- a/dynamic-proxy/Cargo.toml
+++ b/dynamic-proxy/Cargo.toml
@@ -6,20 +6,19 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.89"
 bytes = "1.7.2"
+futures-util = "0.3.31"
 http = "1.1.0"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
-hyper = "1.4.1"
+hyper = { version = "1.4.1", features = ["client"] }
 hyper-util = { version = "0.1.8", features = ["http1", "http2", "server", "server-graceful", "server-auto"] }
 pin-project-lite = "0.2.14"
 rustls = { version = "0.23.13", features = ["ring"] }
-thiserror = "1.0.63"
 serde = { version = "1.0.210", features = ["derive"] }
+thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
 tokio-rustls = "0.26.0"
 tracing = "0.1.40"
-tower = "0.5.1"
-futures-util = "0.3.31"
 
 [dev-dependencies]
 axum = { version = "0.7.6", features = ["http2", "ws"] }

--- a/dynamic-proxy/Cargo.toml
+++ b/dynamic-proxy/Cargo.toml
@@ -10,7 +10,7 @@ http = "1.1.0"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 hyper = "1.4.1"
-hyper-util = { version = "0.1.8", features = ["http1", "http2", "server", "server-graceful", "server-auto", "client", "client-legacy"] }
+hyper-util = { version = "0.1.8", features = ["http1", "http2", "server", "server-graceful", "server-auto"] }
 pin-project-lite = "0.2.14"
 rustls = { version = "0.23.13", features = ["ring"] }
 thiserror = "1.0.63"
@@ -18,6 +18,8 @@ serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
 tokio-rustls = "0.26.0"
 tracing = "0.1.40"
+tower = "0.5.1"
+futures-util = "0.3.31"
 
 [dev-dependencies]
 axum = { version = "0.7.6", features = ["http2", "ws"] }

--- a/dynamic-proxy/src/proxy.rs
+++ b/dynamic-proxy/src/proxy.rs
@@ -10,8 +10,10 @@ use hyper_util::rt::TokioIo;
 use std::{convert::Infallible, net::SocketAddr, time::Duration};
 use tokio::net::TcpStream;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60 * 5); // 5 minutes
 
+/// A boxed future that is responsible for proxying all communication between the client
+/// and upstream server after the initial exchange of headers.
 type BodyFuture = BoxFuture<'static, Result<(), ProxyError>>;
 
 /// A client for proxying HTTP requests to an upstream server.
@@ -121,7 +123,7 @@ impl ProxyClient {
 
         tokio::task::spawn(async move {
             if let Err(err) = conn.with_upgrades().await {
-                println!("Connection failed: {:?}", err);
+                tracing::warn!(?err, "Upstream connection failed.");
             }
         });
 

--- a/dynamic-proxy/src/request.rs
+++ b/dynamic-proxy/src/request.rs
@@ -1,12 +1,8 @@
 use crate::body::{to_simple_body, SimpleBody};
 use bytes::Bytes;
-use http::{
-    request::Parts,
-    uri::{Authority, Scheme},
-    HeaderMap, HeaderName, HeaderValue, Request, Uri,
-};
+use http::{request::Parts, HeaderMap, HeaderName, HeaderValue, Request};
 use http_body::Body;
-use std::{net::SocketAddr, str::FromStr};
+use std::str::FromStr;
 
 /// Represents an HTTP request (from hyper) with helpers for mutating it.
 pub struct MutableRequest<T>
@@ -34,18 +30,6 @@ where
 
     pub fn into_request_with_simple_body(self) -> Request<SimpleBody> {
         Request::from_parts(self.parts, to_simple_body(self.body))
-    }
-
-    /// Rewrite the request so that it points to the given upstream address.
-    pub fn set_upstream_address(&mut self, address: SocketAddr) {
-        let uri = std::mem::take(&mut self.parts.uri);
-        let mut uri_parts = uri.into_parts();
-        uri_parts.scheme = Some(Scheme::HTTP);
-        uri_parts.authority = Some(
-            Authority::try_from(address.to_string())
-                .expect("SocketAddr should always be a valid authority."),
-        );
-        self.parts.uri = Uri::from_parts(uri_parts).expect("URI should always be valid.");
     }
 
     /// Add a header to the request.

--- a/dynamic-proxy/src/upgrade.rs
+++ b/dynamic-proxy/src/upgrade.rs
@@ -47,12 +47,12 @@ impl UpgradeHandler {
     pub async fn run(self) -> Result<(), ProxyError> {
         let response = hyper::upgrade::on(self.response)
             .await
-            .map_err(ProxyError::UpgradeError)?;
+            .map_err(ProxyError::ResponseUpgradeError)?;
         let mut response = TokioIo::new(response);
 
         let request = hyper::upgrade::on(self.request)
             .await
-            .map_err(ProxyError::UpgradeError)?;
+            .map_err(ProxyError::RequestUpgradeError)?;
         let mut request = TokioIo::new(request);
 
         copy_bidirectional(&mut request, &mut response)

--- a/dynamic-proxy/tests/test_proxy_request.rs
+++ b/dynamic-proxy/tests/test_proxy_request.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use crate::common::simple_axum_server::SimpleAxumServer;
 use anyhow::Result;
 use bytes::Bytes;
@@ -11,6 +9,7 @@ use dynamic_proxy::{
 };
 use http::{Method, Request, StatusCode};
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use std::net::SocketAddr;
 use tokio::net::TcpListener;
 
 mod common;
@@ -23,11 +22,12 @@ async fn make_request(req: Request<BoxBody<Bytes, BoxedError>>) -> Result<Reques
     let host = req.parts.uri.host().unwrap().to_string();
     req.add_header("host", &host);
 
-    let (res, upgrade_handler) = proxy_client.request(server.addr(), req.into_request()).await.unwrap();
+    let (res, upgrade_handler) = proxy_client
+        .request(server.addr(), req.into_request())
+        .await
+        .unwrap();
     assert_eq!(res.status(), StatusCode::OK);
     assert!(upgrade_handler.is_none());
-
-    
 
     let body = res.into_body().collect().await.unwrap().to_bytes();
     let result: RequestInfo = serde_json::from_slice(&body).unwrap();
@@ -125,6 +125,7 @@ async fn test_proxy_no_upstream() {
     let addr = SocketAddr::from(([127, 0, 0, 1], 0));
     let tcp_listener = TcpListener::bind(addr).await.unwrap();
     let addr = tcp_listener.local_addr().unwrap();
+    drop(tcp_listener);
 
     let req = Request::builder()
         .method(Method::GET)
@@ -135,7 +136,6 @@ async fn test_proxy_no_upstream() {
     let client = ProxyClient::new();
     let (result, upgrade_handler) = client.request(addr, req).await.unwrap();
 
-    // expect error HTTP 502 after timeout
-    assert_eq!(result.status(), StatusCode::GATEWAY_TIMEOUT);
+    assert_eq!(result.status(), StatusCode::BAD_GATEWAY);
     assert!(upgrade_handler.is_none());
 }

--- a/plane/plane-tests/tests/proxy.rs
+++ b/plane/plane-tests/tests/proxy.rs
@@ -12,8 +12,8 @@ use plane::{
 };
 use plane_test_macro::plane_test;
 use reqwest::StatusCode;
-use tokio::net::TcpListener;
 use std::{net::SocketAddr, str::FromStr};
+use tokio::net::TcpListener;
 
 mod common;
 

--- a/plane/plane-tests/tests/proxy.rs
+++ b/plane/plane-tests/tests/proxy.rs
@@ -12,6 +12,7 @@ use plane::{
 };
 use plane_test_macro::plane_test;
 use reqwest::StatusCode;
+use tokio::net::TcpListener;
 use std::{net::SocketAddr, str::FromStr};
 
 mod common;
@@ -108,47 +109,46 @@ async fn proxy_backend_unreachable(env: TestEnvironment) {
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
 }
 
-// TODO: Re-enable when timeout is re-implemented. (Paul 2024-10-11)
-// #[plane_test]
-// async fn proxy_backend_timeout(env: TestEnvironment) {
-//     // We will start a listener, but never respond on it, to simulate a timeout.
-//     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-//         .await
-//         .unwrap();
-//     let addr = listener.local_addr().unwrap();
+#[plane_test]
+async fn proxy_backend_timeout(env: TestEnvironment) {
+    // We will start a listener, but never respond on it, to simulate a timeout.
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
 
-//     let mut proxy = MockProxy::new().await;
-//     let port = proxy.port();
-//     let cluster = ClusterName::from_str(&format!("plane.test:{}", port)).unwrap();
-//     let url = format!("http://plane.test:{port}/abc123/");
-//     let client = localhost_client();
-//     let handle = tokio::spawn(client.get(url).send());
+    let mut proxy = MockProxy::new().await;
+    let port = proxy.port();
+    let cluster = ClusterName::from_str(&format!("plane.test:{}", port)).unwrap();
+    let url = format!("http://plane.test:{port}/abc123/");
+    let client = localhost_client();
+    let handle = tokio::spawn(client.get(url).send());
 
-//     let route_info_request = proxy.recv_route_info_request().await;
-//     assert_eq!(
-//         route_info_request.token,
-//         BearerToken::from("abc123".to_string())
-//     );
+    let route_info_request = proxy.recv_route_info_request().await;
+    assert_eq!(
+        route_info_request.token,
+        BearerToken::from("abc123".to_string())
+    );
 
-//     proxy
-//         .send_route_info_response(RouteInfoResponse {
-//             token: BearerToken::from("abc123".to_string()),
-//             route_info: Some(RouteInfo {
-//                 backend_id: BackendName::new_random(),
-//                 address: BackendAddr(addr),
-//                 secret_token: SecretToken::from("secret".to_string()),
-//                 cluster,
-//                 user: None,
-//                 user_data: None,
-//                 subdomain: None,
-//             }),
-//         })
-//         .await;
+    proxy
+        .send_route_info_response(RouteInfoResponse {
+            token: BearerToken::from("abc123".to_string()),
+            route_info: Some(RouteInfo {
+                backend_id: BackendName::new_random(),
+                address: BackendAddr(addr),
+                secret_token: SecretToken::from("secret".to_string()),
+                cluster,
+                user: None,
+                user_data: None,
+                subdomain: None,
+            }),
+        })
+        .await;
 
-//     let response = handle.await.unwrap().unwrap();
+    let response = handle.await.unwrap().unwrap();
 
-//     assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
-// }
+    assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+}
 
 #[plane_test]
 async fn proxy_backend_accepts(env: TestEnvironment) {


### PR DESCRIPTION
I need to thing through whether this is even a good idea. It simplifies the code a bit, but also gets rid of connection pools.

The main advantage I think is that we can apply the timeout _just_ to the transfer of headers, so we can have something like long-polling that doesn't time out. But I haven't convinced myself that that's more of a win than connection pooling given the use cases we see.