### PR TITLE
Version 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,32 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dynamic-proxy"
-version = "0.5.0"
-dependencies = [
- "anyhow",
- "axum",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "rcgen",
- "reqwest",
- "rustls",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tokio-tungstenite",
- "tracing",
-]
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,7 +1844,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plane"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "acme2-eab",
  "anyhow",
@@ -1884,7 +1858,6 @@ dependencies = [
  "colored",
  "dashmap",
  "data-encoding",
- "dynamic-proxy",
  "futures-util",
  "http-body",
  "hyper",
@@ -1892,6 +1865,7 @@ dependencies = [
  "lru",
  "openssl",
  "pem",
+ "plane-dynamic-proxy",
  "rand",
  "reqwest",
  "rusqlite",
@@ -1926,6 +1900,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "plane-dynamic-proxy"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "tracing",
+]
+
+[[package]]
 name = "plane-test-macro"
 version = "0.1.0"
 dependencies = [
@@ -1936,19 +1936,19 @@ dependencies = [
 
 [[package]]
 name = "plane-tests"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "bollard",
  "chrono",
- "dynamic-proxy",
  "futures-util",
  "http",
  "http-body-util",
  "hyper",
  "plane-dynamic",
+ "plane-dynamic-proxy",
  "plane-test-macro",
  "reqwest",
  "serde",

--- a/dynamic-proxy/Cargo.toml
+++ b/dynamic-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "dynamic-proxy"
-version = "0.5.0"
+name = "plane-dynamic-proxy"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]

--- a/dynamic-proxy/tests/common/hello_world_service.rs
+++ b/dynamic-proxy/tests/common/hello_world_service.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
-use plane_dynamic_proxy::body::{to_simple_body, SimpleBody};
 use http_body_util::{BodyExt, Full};
 use hyper::{body::Incoming, service::Service, Request, Response};
+use plane_dynamic_proxy::body::{to_simple_body, SimpleBody};
 use std::{convert::Infallible, future::Future, pin::Pin};
 
 /// A service that returns a greeting with the X-Forwarded-For and X-Forwarded-Proto headers.

--- a/dynamic-proxy/tests/common/hello_world_service.rs
+++ b/dynamic-proxy/tests/common/hello_world_service.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use dynamic_proxy::body::{to_simple_body, SimpleBody};
+use plane_dynamic_proxy::body::{to_simple_body, SimpleBody};
 use http_body_util::{BodyExt, Full};
 use hyper::{body::Incoming, service::Service, Request, Response};
 use std::{convert::Infallible, future::Future, pin::Pin};

--- a/dynamic-proxy/tests/common/simple_upgrade_service.rs
+++ b/dynamic-proxy/tests/common/simple_upgrade_service.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use dynamic_proxy::body::{to_simple_body, SimpleBody};
+use plane_dynamic_proxy::body::{to_simple_body, SimpleBody};
 use http::header::CONNECTION;
 use http_body_util::{Empty, Full};
 use hyper::{

--- a/dynamic-proxy/tests/common/simple_upgrade_service.rs
+++ b/dynamic-proxy/tests/common/simple_upgrade_service.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use plane_dynamic_proxy::body::{to_simple_body, SimpleBody};
 use http::header::CONNECTION;
 use http_body_util::{Empty, Full};
 use hyper::{
@@ -10,6 +9,7 @@ use hyper::{
     Request, Response, StatusCode,
 };
 use hyper_util::rt::TokioIo;
+use plane_dynamic_proxy::body::{to_simple_body, SimpleBody};
 use std::{convert::Infallible, future::Future, pin::Pin};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/dynamic-proxy/tests/graceful.rs
+++ b/dynamic-proxy/tests/graceful.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
+use hyper::StatusCode;
 use plane_dynamic_proxy::body::to_simple_body;
 use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
-use hyper::StatusCode;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;

--- a/dynamic-proxy/tests/graceful.rs
+++ b/dynamic-proxy/tests/graceful.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
-use dynamic_proxy::body::to_simple_body;
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
+use plane_dynamic_proxy::body::to_simple_body;
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use hyper::StatusCode;
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -11,7 +11,7 @@ use tokio::time::Duration;
 
 async fn slow_hello_world(
     _: hyper::Request<hyper::body::Incoming>,
-) -> Result<hyper::Response<dynamic_proxy::body::SimpleBody>, Infallible> {
+) -> Result<hyper::Response<plane_dynamic_proxy::body::SimpleBody>, Infallible> {
     tokio::time::sleep(Duration::from_secs(1)).await; // emulate slow request
     let body = http_body_util::Full::<Bytes>::from("Hello, world!".to_owned());
     let body = to_simple_body(body);

--- a/dynamic-proxy/tests/graceful_https.rs
+++ b/dynamic-proxy/tests/graceful_https.rs
@@ -1,8 +1,8 @@
 use bytes::Bytes;
 use common::cert::StaticCertificateResolver;
-use dynamic_proxy::body::to_simple_body;
-use dynamic_proxy::server::HttpsConfig;
-use dynamic_proxy::server::SimpleHttpServer;
+use plane_dynamic_proxy::body::to_simple_body;
+use plane_dynamic_proxy::server::HttpsConfig;
+use plane_dynamic_proxy::server::SimpleHttpServer;
 use hyper::StatusCode;
 use std::convert::Infallible;
 use std::net::SocketAddr;

--- a/dynamic-proxy/tests/graceful_https.rs
+++ b/dynamic-proxy/tests/graceful_https.rs
@@ -1,9 +1,9 @@
 use bytes::Bytes;
 use common::cert::StaticCertificateResolver;
+use hyper::StatusCode;
 use plane_dynamic_proxy::body::to_simple_body;
 use plane_dynamic_proxy::server::HttpsConfig;
 use plane_dynamic_proxy::server::SimpleHttpServer;
-use hyper::StatusCode;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;

--- a/dynamic-proxy/tests/hello_world_http.rs
+++ b/dynamic-proxy/tests/hello_world_http.rs
@@ -1,6 +1,6 @@
 use common::hello_world_service::HelloWorldService;
-use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use hyper::StatusCode;
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 

--- a/dynamic-proxy/tests/hello_world_http.rs
+++ b/dynamic-proxy/tests/hello_world_http.rs
@@ -1,5 +1,5 @@
 use common::hello_world_service::HelloWorldService;
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use hyper::StatusCode;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;

--- a/dynamic-proxy/tests/https_test.rs
+++ b/dynamic-proxy/tests/https_test.rs
@@ -1,5 +1,5 @@
 use common::{cert::StaticCertificateResolver, hello_world_service::HelloWorldService};
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 

--- a/dynamic-proxy/tests/test_http_redirect.rs
+++ b/dynamic-proxy/tests/test_http_redirect.rs
@@ -1,8 +1,8 @@
+use http::{header, StatusCode};
 use plane_dynamic_proxy::{
     https_redirect::HttpsRedirectService,
     server::{HttpsConfig, SimpleHttpServer},
 };
-use http::{header, StatusCode};
 use reqwest::{Response, Url};
 use std::net::{IpAddr, SocketAddr};
 use tokio::net::TcpListener;

--- a/dynamic-proxy/tests/test_http_redirect.rs
+++ b/dynamic-proxy/tests/test_http_redirect.rs
@@ -1,4 +1,4 @@
-use dynamic_proxy::{
+use plane_dynamic_proxy::{
     https_redirect::HttpsRedirectService,
     server::{HttpsConfig, SimpleHttpServer},
 };

--- a/dynamic-proxy/tests/test_http_versions.rs
+++ b/dynamic-proxy/tests/test_http_versions.rs
@@ -1,6 +1,6 @@
 use common::hello_world_service::HelloWorldService;
-use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use hyper::StatusCode;
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 

--- a/dynamic-proxy/tests/test_http_versions.rs
+++ b/dynamic-proxy/tests/test_http_versions.rs
@@ -1,5 +1,5 @@
 use common::hello_world_service::HelloWorldService;
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use hyper::StatusCode;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;

--- a/dynamic-proxy/tests/test_proxy_request.rs
+++ b/dynamic-proxy/tests/test_proxy_request.rs
@@ -2,13 +2,13 @@ use crate::common::simple_axum_server::SimpleAxumServer;
 use anyhow::Result;
 use bytes::Bytes;
 use common::simple_axum_server::RequestInfo;
+use http::{Method, Request, StatusCode};
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use plane_dynamic_proxy::{
     body::{simple_empty_body, to_simple_body, BoxedError},
     proxy::ProxyClient,
     request::MutableRequest,
 };
-use http::{Method, Request, StatusCode};
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
 
 mod common;
 

--- a/dynamic-proxy/tests/test_proxy_request.rs
+++ b/dynamic-proxy/tests/test_proxy_request.rs
@@ -2,7 +2,7 @@ use crate::common::simple_axum_server::SimpleAxumServer;
 use anyhow::Result;
 use bytes::Bytes;
 use common::simple_axum_server::RequestInfo;
-use dynamic_proxy::{
+use plane_dynamic_proxy::{
     body::{simple_empty_body, to_simple_body, BoxedError},
     proxy::ProxyClient,
     request::MutableRequest,

--- a/dynamic-proxy/tests/test_proxy_websocket.rs
+++ b/dynamic-proxy/tests/test_proxy_websocket.rs
@@ -1,13 +1,13 @@
 use common::websocket_echo_server::WebSocketEchoServer;
+use futures_util::{SinkExt, StreamExt};
+use http::{Request, Response};
+use hyper::{body::Incoming, service::Service};
 use plane_dynamic_proxy::{
     body::SimpleBody,
     proxy::ProxyClient,
     request::MutableRequest,
     server::{HttpsConfig, SimpleHttpServer},
 };
-use futures_util::{SinkExt, StreamExt};
-use http::{Request, Response};
-use hyper::{body::Incoming, service::Service};
 use std::{future::Future, net::SocketAddr, pin::Pin};
 use tokio::net::TcpListener;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};

--- a/dynamic-proxy/tests/test_proxy_websocket.rs
+++ b/dynamic-proxy/tests/test_proxy_websocket.rs
@@ -1,5 +1,5 @@
 use common::websocket_echo_server::WebSocketEchoServer;
-use dynamic_proxy::{
+use plane_dynamic_proxy::{
     body::SimpleBody,
     proxy::ProxyClient,
     request::MutableRequest,

--- a/dynamic-proxy/tests/test_upgrade.rs
+++ b/dynamic-proxy/tests/test_upgrade.rs
@@ -1,12 +1,12 @@
 use bytes::Bytes;
 use common::simple_upgrade_service::SimpleUpgradeService;
-use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use http_body_util::Empty;
 use hyper::{
     header::{HeaderValue, CONNECTION, UPGRADE},
     Request, StatusCode,
 };
 use hyper_util::rt::TokioIo;
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use std::net::SocketAddr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/dynamic-proxy/tests/test_upgrade.rs
+++ b/dynamic-proxy/tests/test_upgrade.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use common::simple_upgrade_service::SimpleUpgradeService;
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use http_body_util::Empty;
 use hyper::{
     header::{HeaderValue, CONNECTION, UPGRADE},

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 default-run = "plane"
 description = "Session backend orchestrator for ambitious browser-based apps."
@@ -22,7 +22,6 @@ clap = { version = "4.4.10", features = ["derive"] }
 colored = "2.0.4"
 dashmap = "6.1"
 data-encoding = "2.4.0"
-dynamic-proxy = { path="../dynamic-proxy" }
 futures-util = "0.3.29"
 http-body = "1.0.1"
 hyper = { version = "1.4.1", features = ["server"] }
@@ -30,6 +29,7 @@ hyper-util = { version = "0.1.9", features = ["client", "client-legacy", "http1"
 lru = "0.12.1"
 openssl = "0.10.66"
 pem = "3.0.2"
+plane-dynamic-proxy = { path="../dynamic-proxy", version = "0.5.1" }
 rand = "0.8.5"
 reqwest = { version = "0.12.8", features = ["json", "rustls-tls"], default-features = false }
 rusqlite = { version = "0.32", features = ["bundled", "serde_json"] }

--- a/plane/plane-tests/Cargo.toml
+++ b/plane/plane-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-tests"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]
@@ -9,12 +9,12 @@ async-trait = "0.1.74"
 axum = { version = "0.7.5", features = ["ws"] }
 bollard = "0.17.0"
 chrono = { version = "0.4.31", features = ["serde"] }
-dynamic-proxy = { path = "../../dynamic-proxy" }
 futures-util = "0.3.29"
 http = "1.1.0"
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["server"] }
 plane = { path = "../plane-dynamic", package = "plane-dynamic" }
+plane-dynamic-proxy = { path = "../../dynamic-proxy" }
 plane-test-macro = { path = "plane-test-macro" }
 reqwest = { version = "0.12.8", features = ["json", "rustls-tls"], default-features = false }
 serde = "1.0.210"

--- a/plane/plane-tests/tests/common/proxy_mock.rs
+++ b/plane/plane-tests/tests/common/proxy_mock.rs
@@ -1,9 +1,9 @@
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use plane::{
     names::BackendName,
     protocol::{RouteInfoRequest, RouteInfoResponse},
     proxy::{connection_monitor::BackendEntry, proxy_server::ProxyState},
 };
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use std::net::SocketAddr;
 use tokio::{net::TcpListener, sync::mpsc};
 

--- a/plane/plane-tests/tests/common/test_env.rs
+++ b/plane/plane-tests/tests/common/test_env.rs
@@ -3,7 +3,6 @@ use super::{
     resources::{database::DevDatabase, pebble::Pebble},
 };
 use chrono::Duration;
-use dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use plane::{
     client::PlaneClient,
     controller::ControllerServer,
@@ -25,6 +24,7 @@ use plane::{
     types::{ClusterName, DronePoolName},
     util::random_string,
 };
+use plane_dynamic_proxy::server::{HttpsConfig, SimpleHttpServer};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},

--- a/plane/src/proxy/cert_manager.rs
+++ b/plane/src/proxy/cert_manager.rs
@@ -10,7 +10,7 @@ use acme2_eab::{
 };
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
-use dynamic_proxy::tokio_rustls::rustls::{
+use plane_dynamic_proxy::tokio_rustls::rustls::{
     server::{ClientHello, ResolvesServerCert},
     sign::CertifiedKey,
 };

--- a/plane/src/proxy/cert_pair.rs
+++ b/plane/src/proxy/cert_pair.rs
@@ -1,10 +1,10 @@
 use crate::log_types::LoggableTime;
 use anyhow::{anyhow, Result};
-use dynamic_proxy::rustls::{
+use pem::Pem;
+use plane_dynamic_proxy::rustls::{
     crypto::aws_lc_rs::sign::any_supported_type, pki_types::PrivateKeyDer,
 };
-use dynamic_proxy::tokio_rustls::rustls::sign::CertifiedKey;
-use pem::Pem;
+use plane_dynamic_proxy::tokio_rustls::rustls::sign::CertifiedKey;
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
 use std::{fs::Permissions, io, os::unix::fs::PermissionsExt, path::Path};

--- a/plane/src/proxy/mod.rs
+++ b/plane/src/proxy/mod.rs
@@ -3,7 +3,7 @@ use crate::names::ProxyName;
 use crate::proxy::cert_manager::watcher_manager_pair;
 use crate::{client::PlaneClient, signals::wait_for_shutdown_signal, types::ClusterName};
 use anyhow::Result;
-use dynamic_proxy::server::{
+use plane_dynamic_proxy::server::{
     ServerWithHttpRedirect, ServerWithHttpRedirectConfig, ServerWithHttpRedirectHttpsConfig,
 };
 use proxy_server::ProxyState;

--- a/plane/src/proxy/proxy_server.rs
+++ b/plane/src/proxy/proxy_server.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{names::Name, protocol::RouteInfo, SERVER_NAME};
 use bytes::Bytes;
-use dynamic_proxy::{
+use plane_dynamic_proxy::{
     body::{simple_empty_body, SimpleBody},
     hyper::{
         body::{Body, Incoming},

--- a/plane/src/proxy/request.rs
+++ b/plane/src/proxy/request.rs
@@ -1,5 +1,5 @@
 use crate::types::{BearerToken, ClusterName};
-use dynamic_proxy::hyper::http::uri::{self, PathAndQuery};
+use plane_dynamic_proxy::hyper::http::uri::{self, PathAndQuery};
 use std::str::FromStr;
 
 // If a cluster name does not specify a port, :443 is implied.


### PR DESCRIPTION
Version 0.5.0 was not published to crates.io because it depended on the repo-local crate `dynamic-proxy`.

This bumps the version to 0.5.1, and renames `dynamic-proxy` to `plane-dynamic-proxy` with the intent of publishing it as its own crate. (At least for now, I like this better than incorporating it in Plane, because it has its own test suite that we would have to co-mingle with Plane's if we were to merge them)