### PR TITLE
Mark plane-tests and plane-dynamic as publish=false

### DIFF
--- a/plane/plane-dynamic/Cargo.toml
+++ b/plane/plane-dynamic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plane-dynamic"
 version = "0.4.9"
 edition = "2021"
+publish = false
 
 [dependencies]
 plane = { path = ".." }

--- a/plane/plane-tests/Cargo.toml
+++ b/plane/plane-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plane-tests"
 version = "0.5.1"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1.0.75"


### PR DESCRIPTION
When we only published one `plane` crate this didn't matter because we could do `cargo publish` by hand, but now that we have a couple published crates in the repo it's nice to be able to run `cargo ws publish` which requires this to be set.