### PR TITLE
drone failed to mark backend as terminated

### DIFF
--- a/plane/src/drone/executor.rs
+++ b/plane/src/drone/executor.rs
@@ -177,8 +177,8 @@ impl Executor {
                 let callback = {
                     let state_store = self.state_store.clone();
                     let backend_id = backend_id.clone();
-                    let timestamp = chrono::Utc::now();
                     move |state: &BackendState| {
+                        let timestamp = chrono::Utc::now();
                         state_store
                             .lock()
                             .expect("State store lock poisoned.")

--- a/plane/src/drone/runtime/docker/mod.rs
+++ b/plane/src/drone/runtime/docker/mod.rs
@@ -201,15 +201,13 @@ impl Runtime for DockerRuntime {
             .await
         {
             Ok(details) => {
-                if let Some(state) = details.state {
-                    if !state.running.unwrap_or(false) {
-                        tracing::warn!(
-                            %container_id,
-                            %backend_id,
-                            "Container could not be terminated, because it is not running."
-                        );
-                        return Ok(false);
-                    }
+                if !details.state.and_then(|s| s.running).unwrap_or(false) {
+                    tracing::warn!(
+                        %container_id,
+                        %backend_id,
+                        "Container could not be terminated, because it is not running."
+                    );
+                    return Ok(false);
                 }
             }
             Err(bollard::errors::Error::DockerResponseServerError {


### PR DESCRIPTION
We've observed failure modes where a container exit is not detected. In those cases, we expect that a termination request will see that the container is no longer running due to docker returning an error when calling `stop_container`/`kill_container`. Docker _doesn't_ error when calling `stop_container()` on an already stopped container, however. This has caused termination loops that never fully succeed, leaving the drone thinking the container is still running, and re-renewing its key over and over. This PR fixes this issue by checking the container's status before calling `terminate()` on it.

This still doesn't address these two issues, however:
(1) we aren't detecting the container exit in some cases which causes this failure mode in the first place
(2) we should make `terminating` loops eventually resort to `hard-terminating`