### PR TITLE
bump event pubsub channel capacity to 1000

### DIFF
--- a/plane/src/database/subscribe.rs
+++ b/plane/src/database/subscribe.rs
@@ -140,7 +140,7 @@ pub struct Notification<T> {
 impl EventSubscriptionManager {
     pub fn new(db: &PgPool) -> Self {
         let listeners: ListenerMap = Arc::new(RwLock::new(HashMap::new()));
-        let all_events = Sender::new(100);
+        let all_events = Sender::new(1000);
 
         let handle = {
             let all_events = all_events.clone();
@@ -334,7 +334,7 @@ impl EventSubscriptionManager {
                 }
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
-                let sender = Sender::new(100);
+                let sender = Sender::new(1000);
                 let receiver = sender.subscribe();
                 entry.insert(Box::new(sender));
                 Subscription {


### PR DESCRIPTION
We have a lot of events flowing through this channel and 100 is a very low threshold, so let's bump that to 1000.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase event channel capacity to 1000 in `EventSubscriptionManager` to handle more events.
> 
>   - **Behavior**:
>     - Increase event channel capacity from 100 to 1000 in `EventSubscriptionManager::new()` and `EventSubscriptionManager::subscribe()`.
>   - **Files**:
>     - `subscribe.rs`: Modify `Sender::new()` calls to increase channel capacity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jamsocket%2Fplane&utm_source=github&utm_medium=referral)<sup> for 1bb226d68e874dfc5bae5d74df2f0f844232149a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->