### PR TITLE
Add backend status stream endpoint

### DIFF
--- a/plane/src/client/mod.rs
+++ b/plane/src/client/mod.rs
@@ -13,7 +13,7 @@ use reqwest::{Response, StatusCode};
 use serde::de::DeserializeOwned;
 use url::{form_urlencoded, Url};
 pub mod controller_address;
-mod sse;
+pub mod sse;
 
 #[derive(thiserror::Error, Debug)]
 pub enum PlaneClientError {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add backend status stream endpoint and refactor admin commands to utilize SSE for status updates.
> 
>   - **Behavior**:
>     - Adds `BackendStatus` command to `AdminCommand` in `admin.rs` to stream backend status updates.
>     - Introduces `print_status_stream()` in `admin.rs` to handle streaming of backend status until a specified status is reached.
>     - Refactors `Connect` and `Terminate` commands in `admin.rs` to use `print_status_stream()` for status updates.
>   - **Client**:
>     - Exposes `sse` module in `client/mod.rs` for public use.
>     - Adds `backend_status_stream()` in `PlaneClient` in `client/mod.rs` to initiate SSE requests for backend status updates.
>   - **Misc**:
>     - Minor import reordering in `admin.rs` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jamsocket%2Fplane&utm_source=github&utm_medium=referral)<sup> for 65c5a3fa18308e0ad3c52ef1b440ecde04f9f6cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->