### PR TITLE
make termination reason serialization match valuable

### DIFF
--- a/plane/src/types/backend_state.rs
+++ b/plane/src/types/backend_state.rs
@@ -244,10 +244,10 @@ impl valuable::Valuable for TerminationReason {
         match self {
             TerminationReason::Swept => valuable::Value::String("swept"),
             TerminationReason::External => valuable::Value::String("external"),
-            TerminationReason::KeyExpired => valuable::Value::String("key_expired"),
+            TerminationReason::KeyExpired => valuable::Value::String("keyexpired"),
             TerminationReason::Lost => valuable::Value::String("lost"),
-            TerminationReason::StartupTimeout => valuable::Value::String("startup_timeout"),
-            TerminationReason::InternalError => valuable::Value::String("internal_error"),
+            TerminationReason::StartupTimeout => valuable::Value::String("startuptimeout"),
+            TerminationReason::InternalError => valuable::Value::String("internalerror"),
         }
     }
 


### PR DESCRIPTION
The termination reason Valuable "serialization" differs from the serde serialization. Let's make them match each other to avoid confusion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Aligns `TerminationReason` serialization in `plane/src/types/backend_state.rs` to match `valuable` and `serde` formats.
> 
>   - **Behavior**:
>     - Aligns `valuable::Valuable` serialization of `TerminationReason` with `serde` serialization.
>     - Changes string representations: `key_expired` to `keyexpired`, `startup_timeout` to `startuptimeout`, `internal_error` to `internalerror` in `TerminationReason`.
>   - **Files**:
>     - Modifies `plane/src/types/backend_state.rs` to update `Valuable` implementation for `TerminationReason`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jamsocket%2Fplane&utm_source=github&utm_medium=referral)<sup> for 3e5fbd8b55aaf737fea0ef355e9c53aee15ec8af. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->