### PR TITLE
Add a timeout to graceful termination

### DIFF
--- a/plane/src/admin.rs
+++ b/plane/src/admin.rs
@@ -12,7 +12,6 @@ use crate::{
 use chrono::Duration;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use futures_util::{Stream, StreamExt};
 use std::path::PathBuf;
 use url::Url;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a 2-second timeout for graceful server termination in `ControllerServer` and remove unused imports in `admin.rs`.
> 
>   - **Behavior**:
>     - Add `TERMINATE_TIMEOUT_DURATION` constant in `controller/mod.rs` to set a 2-second timeout for graceful server termination.
>     - Modify `terminate()` in `ControllerServer` to use `tokio::time::timeout` for server shutdown.
>     - Log a warning if the server does not terminate gracefully within the timeout.
>   - **Misc**:
>     - Remove unused import `Stream` and `StreamExt` from `admin.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jamsocket%2Fplane&utm_source=github&utm_medium=referral)<sup> for 02566efa4d79845b5727ec1a4b937e2dbb1a8dbd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->