### PR TITLE
Simplify memory swap

### DIFF
--- a/plane/src/drone/key_manager.rs
+++ b/plane/src/drone/key_manager.rs
@@ -124,14 +124,14 @@ impl KeyManager {
         self.sender.replace(sender);
 
         for (backend, (acquired_key, handle)) in self.handles.iter_mut() {
-            let mut new_handle = GuardHandle::new(renew_key_loop(
+            let new_handle = GuardHandle::new(renew_key_loop(
                 acquired_key.clone(),
                 backend.clone(),
                 self.sender.clone(),
                 self.executor.clone(),
             ));
 
-            std::mem::swap(handle, &mut new_handle);
+            *handle = new_handle;
         }
     }
 


### PR DESCRIPTION
@rolyatmax caught this, it may have been useful at some point but it no longer is since we aren't doing anything with the result.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `std::mem::swap` with direct assignment in `set_sender()` in `key_manager.rs`.
> 
>   - **Refactor**:
>     - Replace `std::mem::swap` with direct assignment in `set_sender()` in `key_manager.rs` for `handle` update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jamsocket%2Fplane&utm_source=github&utm_medium=referral)<sup> for 7ff722588487822cda249987cdcfa3c017aa6953. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->