### PR TITLE
Don't break build when git is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,7 +1979,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plane"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "acme2-eab",
  "anyhow",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "plane-common"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "plane-dynamic-proxy"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-common"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Client library and common utilities for the Plane session backend orchestrator."
 license = "MIT"

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,13 +1,14 @@
 use std::process::Command;
 
 fn main() {
-    let output = Command::new("git")
+    let git_hash = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()
-        .expect("Failed to execute git command");
-
-    let git_hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let git_hash: String = git_hash.chars().take(8).collect();
+        .map(|output| {
+            let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            hash.chars().take(8).collect::<String>()
+        })
+        .unwrap_or_else(|_| String::from("unknown"));
 
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/dynamic-proxy/Cargo.toml
+++ b/dynamic-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane-dynamic-proxy"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Dynamic proxy crate for Plane"
 repository = "https://github.com/jamsocket/plane"

--- a/plane/Cargo.toml
+++ b/plane/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plane"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 default-run = "plane"
 description = "Session backend orchestrator for ambitious browser-based apps."


### PR DESCRIPTION
If git is missing, the build script will fail. This changes it so that it uses the string `unknown` instead of the version.

This version is currently only used to log a warning if there is a version mismatch between the client and server. We should switch to using only the version number for this soon anyway now that the protocol is more stable.