### PR TITLE
Use `UnsyncBoxBody` instead of `BoxBody`

### DIFF
--- a/dynamic-proxy/src/body.rs
+++ b/dynamic-proxy/src/body.rs
@@ -2,23 +2,23 @@
 
 use bytes::Bytes;
 use http_body::Body;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use http_body_util::{BodyExt, Empty};
 
 pub type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
-pub type SimpleBody = BoxBody<Bytes, BoxedError>;
+pub type SimpleBody = UnsyncBoxBody<Bytes, BoxedError>;
 
 pub fn to_simple_body<B>(body: B) -> SimpleBody
 where
-    B: Body<Data = Bytes> + Send + Sync + 'static,
+    B: Body<Data = Bytes> + Send + 'static,
     B::Error: Into<BoxedError>,
 {
-    body.map_err(|e| e.into() as BoxedError).boxed()
+    body.map_err(|e| e.into() as BoxedError).boxed_unsync()
 }
 
 pub fn simple_empty_body() -> SimpleBody {
     Empty::<Bytes>::new()
         .map_err(|_| unreachable!("Infallable"))
-        .boxed()
+        .boxed_unsync()
 }

--- a/dynamic-proxy/src/request.rs
+++ b/dynamic-proxy/src/request.rs
@@ -11,7 +11,7 @@ use std::{net::SocketAddr, str::FromStr};
 /// Represents an HTTP request (from hyper) with helpers for mutating it.
 pub struct MutableRequest<T>
 where
-    T: Body<Data = Bytes> + Send + Sync + 'static,
+    T: Body<Data = Bytes> + Send + 'static,
     T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     pub parts: Parts,
@@ -20,7 +20,7 @@ where
 
 impl<T> MutableRequest<T>
 where
-    T: Body<Data = Bytes> + Send + Sync + 'static,
+    T: Body<Data = Bytes> + Send + 'static,
     T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     pub fn from_request(request: Request<T>) -> Self {

--- a/dynamic-proxy/tests/test_proxy_request.rs
+++ b/dynamic-proxy/tests/test_proxy_request.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use bytes::Bytes;
 use common::simple_axum_server::RequestInfo;
 use http::{Method, Request, StatusCode};
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use http_body_util::{combinators::UnsyncBoxBody, BodyExt, Full};
 use plane_dynamic_proxy::{
     body::{simple_empty_body, to_simple_body, BoxedError},
     proxy::ProxyClient,
@@ -12,7 +12,7 @@ use plane_dynamic_proxy::{
 
 mod common;
 
-async fn make_request(req: Request<BoxBody<Bytes, BoxedError>>) -> Result<RequestInfo> {
+async fn make_request(req: Request<UnsyncBoxBody<Bytes, BoxedError>>) -> Result<RequestInfo> {
     let server = SimpleAxumServer::new().await;
     let proxy_client = ProxyClient::new();
 


### PR DESCRIPTION
We currently use `BoxBody` extensively, which [requires the body to be `Sync`](https://docs.rs/http-body-util/latest/http_body_util/combinators/struct.BoxBody.html), even though we don't actually rely on the `Body` being `Sync` in our code.

[Axum uses `UnsyncBoxBody`](https://docs.rs/axum-core/0.5.0/src/axum_core/body.rs.html#14) instead, which is like `BoxBody` but allows the contained body to be `!Sync`. So when we get a `Body` from Axum, we can't currently pass it to `dynamic_proxy` because it may not be `Sync`, even though our code doesn't actually care if it is `Sync`.

This replaces our use of `BoxBody` with `UnsyncBoxBody`.