### PR TITLE
cert robustness fixes

### DIFF
--- a/plane/src/dns/mod.rs
+++ b/plane/src/dns/mod.rs
@@ -162,7 +162,7 @@ impl AcmeDnsServer {
                     .map(|result| {
                         Record::from_rdata(
                             request.query().name().into(),
-                            300,
+                            1,
                             RData::TXT(TXT::new(vec![result])),
                         )
                     })

--- a/plane/src/proxy/cert_manager.rs
+++ b/plane/src/proxy/cert_manager.rs
@@ -427,11 +427,14 @@ async fn get_certificate(
             }
         }
 
+        // Wait 15 seconds before checking the challenge status.
+        tokio::time::sleep(Duration::from_secs(15)).await;
+
         if challenge.status != ChallengeStatus::Valid {
             tracing::info!("Validating challenge.");
             let challenge = challenge.validate().await.context("Validating challenge")?;
             let challenge = challenge
-                .wait_done(Duration::from_secs(5), 3)
+                .wait_done(Duration::from_secs(5), 6)
                 .await
                 .context("Waiting for challenge")?;
             if challenge.status != ChallengeStatus::Valid {


### PR DESCRIPTION
we're still failing a lot of acme challenges

- Lower TTL on TXT records so that they aren't cached
- Add a 15s pause before attempting to validate after updating the record