### PR TITLE
Remove backends from connection monitor

### DIFF
--- a/plane/src/proxy/connection_monitor.rs
+++ b/plane/src/proxy/connection_monitor.rs
@@ -33,6 +33,10 @@ impl ConnectionMonitor {
         self.listener = Some(Box::new(listener));
     }
 
+    pub fn remove_backend(&mut self, backend_id: &BackendName) {
+        self.backends.remove(backend_id);
+    }
+
     pub fn touch_backend(&mut self, backend_id: &BackendName) {
         match self.backends.entry(backend_id.clone()) {
             Entry::Occupied(mut entry) => {
@@ -126,7 +130,7 @@ impl ConnectionMonitorHandle {
                     let mut monitor_lock = monitor.lock().expect("Monitor lock was poisoned.");
 
                     let Some(backend_entry) = monitor_lock.backends.get_mut(&backend) else {
-                        // This shouldn't happen.
+                        // This will happen if the backend has been removed.
                         continue;
                     };
 
@@ -178,6 +182,13 @@ impl ConnectionMonitorHandle {
             .lock()
             .expect("Monitor lock was poisoned")
             .touch_backend(backend_id);
+    }
+
+    pub fn remove_backend(&self, backend_id: &BackendName) {
+        self.monitor
+            .lock()
+            .expect("Monitor lock was poisoned")
+            .remove_backend(backend_id);
     }
 }
 

--- a/plane/src/proxy/proxy_connection.rs
+++ b/plane/src/proxy/proxy_connection.rs
@@ -72,6 +72,7 @@ impl ProxyConnection {
                             }
                             MessageToProxy::BackendRemoved { backend } => {
                                 state.inner.route_map.remove_backend(&backend);
+                                state.inner.monitor.remove_backend(&backend);
                             }
                         }
                     }


### PR DESCRIPTION
The connection monitor works by visiting backends from a queue. Each queue entry points to a map entry that is currently always expected to exist as an invariant. If it ever is not present, however, we (already) skip it and do _not_ insert the value back in the queue.

This PR piggybacks on this existing behavior to remove backends from being cycled through the queue repeatedly. When we remove a backend from the route map we also remove it from the monitor map, which will cause it to be removed from the queue once it reaches the top.